### PR TITLE
GPU and pcluster updates

### DIFF
--- a/experiments/aws/eks/gpu/eks-config.yaml
+++ b/experiments/aws/eks/gpu/eks-config.yaml
@@ -36,20 +36,3 @@ managedNodeGroups:
     ssh:
       allow: true
       publicKeyPath: ~/.ssh/id_eks.pub
-Build:
-  # https://docs.aws.amazon.com/parallelcluster/latest/ug/Build-v3.html#yaml-build-image-Build-SubnetId
-  InstanceType: p3dn.24xlarge
-  # Note that I did  pcluster list-official-images --region us-east-1
-  # aws-parallelcluster-3.10.1-ubuntu-2204-lts-hvm-x86_64-202407041740 2024-07-04T17-43-29.481Z
-  ParentImage: ami-0fbb05a471fddd45f
-  Imds:
-    ImdsSupport: v2.0
-DevSettings:
-  Cookbook:
-    # https://github.com/aws/aws-parallelcluster/issues/6230
-    # https://github.com/aws/aws-parallelcluster-cookbook/pull/2615
-    # This shows also for OpenRM
-    # https://www.nvidia.com/download/driverResults.aspx/203692/en-us/
-    # 525.105.17
-    ExtraChefAttributes: |
-      {"cluster": {"nvidia": {"enabled": true, "driver_version": "535.161.08", "kernel_open": "false" }}}

--- a/experiments/aws/eks/gpu/eks-config.yaml
+++ b/experiments/aws/eks/gpu/eks-config.yaml
@@ -36,3 +36,20 @@ managedNodeGroups:
     ssh:
       allow: true
       publicKeyPath: ~/.ssh/id_eks.pub
+Build:
+  # https://docs.aws.amazon.com/parallelcluster/latest/ug/Build-v3.html#yaml-build-image-Build-SubnetId
+  InstanceType: p3dn.24xlarge
+  # Note that I did  pcluster list-official-images --region us-east-1
+  # aws-parallelcluster-3.10.1-ubuntu-2204-lts-hvm-x86_64-202407041740 2024-07-04T17-43-29.481Z
+  ParentImage: ami-0fbb05a471fddd45f
+  Imds:
+    ImdsSupport: v2.0
+DevSettings:
+  Cookbook:
+    # https://github.com/aws/aws-parallelcluster/issues/6230
+    # https://github.com/aws/aws-parallelcluster-cookbook/pull/2615
+    # This shows also for OpenRM
+    # https://www.nvidia.com/download/driverResults.aspx/203692/en-us/
+    # 525.105.17
+    ExtraChefAttributes: |
+      {"cluster": {"nvidia": {"enabled": true, "driver_version": "535.161.08", "kernel_open": "false" }}}

--- a/experiments/aws/parallel-cluster/cpu/experiment/README.md
+++ b/experiments/aws/parallel-cluster/cpu/experiment/README.md
@@ -135,9 +135,10 @@ Batch script:
 
 ```console
 oras login ghcr.io --username vsoch
+cd configs/single-node-benchmarks
 srun --time=00:04 -N 2 slurm-single-node-benchmarks.sh
 rm -rf test_file*
-cd ../../data/single-node-benchmarks
+cd ../../data
 oras push ghcr.io/converged-computing/metrics-operator-experiments/performance:aws-parallelcluster-cpu-32node-single-node-benchmarks single-node-benchmarks
 ```
 

--- a/experiments/aws/parallel-cluster/cpu/experiment/configs/single-node-benchmarks/slurm-single-node-benchmarks.sh
+++ b/experiments/aws/parallel-cluster/cpu/experiment/configs/single-node-benchmarks/slurm-single-node-benchmarks.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 sudo /shared/bin/singularity exec /shared/containers/metric-single-node_cpu-zen4-tmpfile.sif \
-    /bin/bash /entrypoint.sh > ../data/single-node-benchmarks/$( hostname )-single-node.out
+    /bin/bash /entrypoint.sh > ../../data/single-node-benchmarks/$( hostname )-single-node.out

--- a/experiments/azure/cyclecloud/gpu/README.md
+++ b/experiments/azure/cyclecloud/gpu/README.md
@@ -36,7 +36,7 @@ cd /shared/containers
 
 # This is the newer build with spack
 singularity pull docker://ghcr.io/converged-computing/metric-lammps-gpu:azure-hpc-reax || true &&  \
-singularity pull docker://ghcr.io/converged-computing/metric-kripke-cpu:azure-hpc || true && \
+singularity pull docker://ghcr.io/converged-computing/metric-kripke-gpu:azure-hpc-gpu-ubuntu2204 || true && \
 singularity pull docker://ghcr.io/converged-computing/metric-amg2023:azure-hpc-gpu-ubuntu2204 || true && \
 singularity pull docker://ghcr.io/converged-computing/metric-laghos:azure-hpc-gpu-ubuntu2204 || true && \
 singularity pull docker://ghcr.io/converged-computing/metric-single-node:cpu || true && \

--- a/experiments/azure/cyclecloud/gpu/experiment/configs/amg/slurm-amg-2n.sh
+++ b/experiments/azure/cyclecloud/gpu/experiment/configs/amg/slurm-amg-2n.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+#SBATCH --job-name=amg-2n
+#SBATCH --nodes=2
+#SBATCH --time=0:20:00
+#SBATCH --exclusive
+
+. /etc/profile.d/modules.sh
+module unload mpi
+module load mpi/hpcx-pmix-2.18
+
+echo "Start time:" $( date +%s )
+export CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7"
+/usr/bin/time -p mpirun -N 2 --map-by ppr:8:node -x UCX_POSIX_USE_PROC_LINK=n \
+                 singularity exec --env UCX_TLS=ud,shm,rc \
+		 --env UCX_UNIFIED_MODE=y --env UCX_NET_DEVICES=mlx5_ib0:1 --env OPAL_PREFIX= \
+		/shared/containers/metric-amg2023_azure-hpc-gpu-ubuntu2204.sif \
+                /opt/spack-environment/.spack-env/view/bin/amg \
+                -n 256 256 128 -P 4 2 2 -problem 2
+echo "End time:" $( date +%s )

--- a/experiments/azure/cyclecloud/gpu/experiment/configs/quicksilver/slurm-quicksilver-16n-gpu.sh
+++ b/experiments/azure/cyclecloud/gpu/experiment/configs/quicksilver/slurm-quicksilver-16n-gpu.sh
@@ -8,7 +8,6 @@
 . /etc/profile.d/modules.sh
 module unload mpi
 ml mpi/hpcx-pmix-2.18
-#ml cuda/11.8.0 #xl/2023.06.28-cuda-11.8.0-gcc-11.2.1
 
 echo "Start time:" $( date +%s )
 export CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7"

--- a/experiments/azure/cyclecloud/gpu/experiment/configs/quicksilver/slurm-quicksilver-1n-gpu.sh
+++ b/experiments/azure/cyclecloud/gpu/experiment/configs/quicksilver/slurm-quicksilver-1n-gpu.sh
@@ -6,9 +6,8 @@
 #SBATCH --exclusive
 
 . /etc/profile.d/modules.sh
-ml mpi/hpcx-pmix-2.18
 module unload mpi
-#xl/2023.06.28-cuda-11.8.0-gcc-11.2.1
+ml mpi/hpcx-pmix-2.18
 
 echo "Start time:" $( date +%s )
 export CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7"

--- a/experiments/azure/cyclecloud/gpu/experiment/configs/quicksilver/slurm-quicksilver-2n-gpu.sh
+++ b/experiments/azure/cyclecloud/gpu/experiment/configs/quicksilver/slurm-quicksilver-2n-gpu.sh
@@ -6,9 +6,8 @@
 #SBATCH --exclusive
 
 . /etc/profile.d/modules.sh
-ml mpi/hpcx-pmix-2.18
 module unload mpi
-#ml cuda/11.8.0 #xl/2023.06.28-cuda-11.8.0-gcc-11.2.1
+ml mpi/hpcx-pmix-2.18
 
 echo "Start time:" $( date +%s )
 export CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7"

--- a/experiments/azure/cyclecloud/gpu/experiment/configs/quicksilver/slurm-quicksilver-4n-gpu.sh
+++ b/experiments/azure/cyclecloud/gpu/experiment/configs/quicksilver/slurm-quicksilver-4n-gpu.sh
@@ -6,9 +6,8 @@
 #SBATCH --exclusive
 
 . /etc/profile.d/modules.sh
-ml mpi/hpcx-pmix-2.18
 module unload mpi
-#ml cuda/11.8.0 #xl/2023.06.28-cuda-11.8.0-gcc-11.2.1
+ml mpi/hpcx-pmix-2.18
 
 echo "Start time:" $( date +%s )
 export CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7"

--- a/experiments/azure/cyclecloud/gpu/experiment/configs/quicksilver/slurm-quicksilver-8n-gpu.sh
+++ b/experiments/azure/cyclecloud/gpu/experiment/configs/quicksilver/slurm-quicksilver-8n-gpu.sh
@@ -6,9 +6,8 @@
 #SBATCH --exclusive
 
 . /etc/profile.d/modules.sh
-ml mpi/hpcx-pmix-2.18
 module unload mpi
-#ml cuda/11.8.0 #xl/2023.06.28-cuda-11.8.0-gcc-11.2.1
+ml mpi/hpcx-pmix-2.18
 
 echo "Start time:" $( date +%s )
 export CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7"


### PR DESCRIPTION
This PR adds updates for CycleCloud and AWS GPU. The AWS GPU build file for ParallelCluster is based on help from AWS engineers.