### PR TITLE
analysis: look at scaling governor

### DIFF
--- a/analysis/test-scaling-governor/README.md
+++ b/analysis/test-scaling-governor/README.md
@@ -1,0 +1,413 @@
+# Scaling Governor
+
+We want to bring up two quick clusters (on AWS and Google) and look at the default setting for the scaling governor ([reference](https://docs.kernel.org/admin-guide/pm/cpufreq.html)). Also note that if you are using node feature discovery, this is set as an [NFD label](https://kubernetes-sigs.github.io/node-feature-discovery/master/usage/features.html#cpu). Since AWS had values varying and Google all the same, I'll look at those two clouds. I suspect Google is set to performance (to max value at the cost of power) and AWS the opposite, but that is my guess. This experiment was run on November 9, 2024.
+
+Note that both seem to be set to "performance" so that doesn't explain it, but there is a lot more interesting stuff to look at with respect to drivers, etc. I am saving the dmesg output and some quick glances I took, and maybe we should do a Hackathon to explore more together.
+
+## AWS
+
+```bash
+time eksctl create cluster --config-file ./eks-config.yaml
+aws eks update-kubeconfig --region us-east-2 --name scaling-government
+```
+
+The default scaling governor is set for performance.
+
+```console
+# cat /sys/module/cpufreq/parameters/default_governor 
+performance
+
+# cat module/cpufreq/parameters/off 
+0
+```
+```console
+for filename in  $(ls /sys/devices/system/cpu/cpu0/cache/index0/); do echo $filename; cat /sys/devices/system/cpu/cpu0/cache/index0/$filename; echo; done
+coherency_line_size
+64
+
+id
+0
+
+level
+1
+
+number_of_sets
+64
+
+physical_line_partition
+1
+
+shared_cpu_list
+0
+
+shared_cpu_map
+00000000,00000000,00000001
+
+size
+32K
+
+type
+Data
+
+uevent
+
+ways_of_associativity
+8
+```
+
+```console
+# ls /sys/devices/cpu/power/
+autosuspend_delay_ms  runtime_active_time  runtime_suspended_time
+control               runtime_status
+[root@ip-192-168-10-93 sys]# cat /sys/devices/cpu/power/runtime_status 
+unsupported
+[root@ip-192-168-10-93 sys]# cat /sys/devices/cpu/power/runtime_active_time 
+0
+[root@ip-192-168-10-93 sys]# cat /sys/devices/cpu/power/runtime_suspended_time 
+0
+[root@ip-192-168-10-93 sys]# cat /sys/devices/cpu/power/control 
+auto
+```
+
+```console
+# cat module/cpuidle/parameters/
+governor  off       
+gke-test-cluster-default-pool-6c51551d-t6mb /sys # cat module/cpuidle/parameters/off 
+0
+```
+
+```console
+ find . -name *governor
+./devices/system/cpu/cpuidle/current_governor
+./module/cpuidle/parameters/governor
+./module/cpufreq/parameters/default_governor
+[root@ip-192-168-10-93 sys]# cat devices/system/cpu/cpuidle/current_governor
+menu
+[root@ip-192-168-10-93 sys]# cat module/cpuidle/parameters/governor 
+
+[root@ip-192-168-10-93 sys]# cat module/cpufreq/parameters/default_governor 
+performance
+```
+
+```console
+# cat /etc/default/grub 
+GRUB_CMDLINE_LINUX_DEFAULT="console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 nvme_core.io_timeout=4294967295 rd.emergency=poweroff rd.shell=0"
+GRUB_TIMEOUT=0
+GRUB_DISABLE_RECOVERY="true"
+GRUB_TERMINAL="ec2-console"
+GRUB_X86_USE_32BIT="true"
+```
+
+```console
+[root@ip-192-168-10-93 sys]# cat /etc/kubernetes/kubelet/kubelet-config.json 
+{
+  "kind": "KubeletConfiguration",
+  "apiVersion": "kubelet.config.k8s.io/v1beta1",
+  "address": "0.0.0.0",
+  "authentication": {
+    "anonymous": {
+      "enabled": false
+    },
+    "webhook": {
+      "cacheTTL": "2m0s",
+      "enabled": true
+    },
+    "x509": {
+      "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+    }
+  },
+  "authorization": {
+    "mode": "Webhook",
+    "webhook": {
+      "cacheAuthorizedTTL": "5m0s",
+      "cacheUnauthorizedTTL": "30s"
+    }
+  },
+  "clusterDomain": "cluster.local",
+  "hairpinMode": "hairpin-veth",
+  "readOnlyPort": 0,
+  "cgroupDriver": "systemd",
+  "cgroupRoot": "/",
+  "featureGates": {
+    "RotateKubeletServerCertificate": true,
+    "KubeletCredentialProviders": true
+  },
+  "protectKernelDefaults": true,
+  "serializeImagePulls": false,
+  "serverTLSBootstrap": true,
+  "tlsCipherSuites": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_128_GCM_SHA256"
+  ],
+  "clusterDNS": [
+    "10.100.0.10"
+  ],
+  "evictionHard": {
+    "memory.available": "100Mi",
+    "nodefs.available": "10%",
+    "nodefs.inodesFree": "5%"
+  },
+  "kubeReserved": {
+    "cpu": "310m",
+    "ephemeral-storage": "1Gi",
+    "memory": "1355Mi"
+  },
+  "providerID": "aws:///us-east-2b/i-046aec8bd20ee1851",
+  "systemReservedCgroup": "/system",
+  "kubeReservedCgroup": "/runtime"
+}
+```
+
+## Google
+
+```bash
+time gcloud container clusters create test-cluster \
+    --threads-per-core=1 \
+    --num-nodes=2 \
+    --machine-type=c2d-standard-112 \
+    --enable-gvnic \
+    --network=mtu9k \
+    --placement-type=COMPACT \
+    --region=us-central1-a \
+    --project=llnl-flux
+```
+
+Note that the content in cpufreq is empty, so I'm going to look at an individual CPU.
+Ah wait, I think I found it elsewhere:
+
+```console
+# cat /sys/module/cpufreq/parameters/default_governor 
+performance
+```
+
+and "off" is set to 0.
+
+```console
+for filename in  $(ls /sys/devices/system/cpu/cpu0/cache/index0/); do echo $filename; cat sys/devices/system/cpu/cpu0/cache/index0/$filename; echo; done
+coherency_line_size
+64
+
+id
+0
+
+level
+1
+
+number_of_sets
+64
+
+physical_line_partition
+1
+
+shared_cpu_list
+0
+
+shared_cpu_map
+000000,00000001
+
+size
+32K
+
+type
+Data
+
+uevent
+
+ways_of_associativity
+8
+```
+
+```console
+cat /sys/devices/system/cpu/cpu0/cache/uevent 
+# empty
+```
+
+```console
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/isolated 
+
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/kernel_max 
+511
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/modalias 
+cpu:type:x86,ven0002fam0019mod0001:feature:,0000,0001,0002,0003,0004,0005,0006,0007,0008,0009,000B,000C,000D,000E,000F,0010,0011,0013,0017,0018,0019,001A,001C,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,002B,002C,002D,002E,002F,0030,0031,0034,0036,0037,0038,0039,003A,003B,003D,0064,0068,006E,0070,0072,0074,0075,0078,0079,007A,007F,0080,0081,0083,0089,008C,008D,0091,0093,0094,0095,0096,0097,0099,009A,009B,009C,009D,009E,009F,00C0,00C1,00C4,00C5,00C6,00C7,00C8,00C9,00D6,00E7,00EA,00ED,00F0,00F1,00F3,00F5,00F6,00F9,00FA,00FB,00FC,010F,0120,0121,0123,0125,0127,0128,0129,012A,0132,0133,0134,0137,0138,013D,0140,0141,0142,0165,016C,016E,016F,0179,01A0,01A2,01AC,01AE,01AF,01B2,01B3,01B8,01BC,01C2,01E0,01E3,0202,0209,020A,0216,0244,029C
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/offline 
+
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/online 
+0-55       
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/possible 
+0-55
+
+```
+
+```console
+# cat /sys/devices/system/cpu/power/runtime_active_time 
+0
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/power/runtime_status 
+unsupported
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/power/runtime_suspended_time 
+0
+```
+```console
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/smt/active 
+0
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/smt/control 
+notsupported
+```
+
+```console
+ ls /sys/devices/system/cpu/cpuidle/
+available_governors  current_driver  current_governor  current_governor_ro
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpuidle/available_governors 
+ladder menu 
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpuidle/current_
+cat: /sys/devices/system/cpu/cpuidle/current_: No such file or directory
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpuidle/current_driver 
+acpi_idle
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpuidle/current_governor
+menu
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpuidle/current_governor_ro 
+menu
+
+```
+
+```console
+# ls /sys/devices/system/cpu/cpu0/cpuidle/state0/
+above  below  default_status  desc  disable  latency  name  power  rejected  residency  time  usage
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/above 
+0
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/below 
+5
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/default_status 
+enabled
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/desc 
+CPUIDLE CORE POLL IDLE
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/disable 
+0
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/latency 
+0
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/name
+POLL
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/power
+4294967295
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/rejected 
+0
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/residency 
+0
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/time 
+274
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/cpuidle/state0/usage 
+5
+```
+
+```console
+/ # cat /sys/devices/system/cpu/cpu0/power/autosuspend_delay_ms 
+cat: /sys/devices/system/cpu/cpu0/power/autosuspend_delay_ms: Input/output error
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/power/control 
+auto
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/power/pm_qos_resume_latency_us 
+0
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/power/runtime_active_time 
+0
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/power/runtime_status 
+unsupported
+gke-test-cluster-default-pool-6c51551d-t6mb / # cat /sys/devices/system/cpu/cpu0/power/runtime_suspended_time 
+0
+gke-test-cluster-default-pool-6c51551d-t6mb / # 
+
+```
+
+```console
+for filename in  $(ls /sys/devices/system/cpu/cpu0/topology/); do echo $filename; cat sys/devices/system/cpu/cpu0/topology/$filename; echo; done
+cluster_cpus
+000000,00000001
+
+cluster_cpus_list
+0
+
+cluster_id
+65535
+
+core_cpus
+000000,00000001
+
+core_cpus_list
+0
+
+core_id
+0
+
+core_siblings
+000000,0fffffff
+
+core_siblings_list
+0-27
+
+die_cpus
+000000,0fffffff
+
+die_cpus_list
+0-27
+
+die_id
+0
+
+package_cpus
+000000,0fffffff
+
+package_cpus_list
+0-27
+
+physical_package_id
+0
+
+thread_siblings
+000000,00000001
+
+thread_siblings_list
+0
+
+```
+
+```console
+processor       : 0
+vendor_id       : AuthenticAMD
+cpu family      : 25
+model           : 1
+model name      : AMD EPYC 7B13
+stepping        : 0
+microcode       : 0xffffffff
+cpu MHz         : 3049.998
+cache size      : 512 KB
+physical id     : 0
+siblings        : 28
+core id         : 0
+cpu cores       : 28
+apicid          : 0
+initial apicid  : 0
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 13
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid tsc_known_freq pni pclmulqdq monitor ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext invpcid_single ssbd ibrs ibpb stibp vmmcall fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 clzero xsaveerptr arat npt nrip_save umip vaes vpclmulqdq rdpid fsrm
+bugs            : sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass srso
+bogomips        : 6099.99
+TLB size        : 2560 4K pages
+clflush size    : 64
+cache_alignment : 64
+address sizes   : 48 bits physical, 48 bits virtual
+power management:
+
+```
+
+kubelet settings
+
+```console
+# cat /etc/default/kubelet 
+KUBELET_OPTS="--v=2 --cloud-provider=external --experimental-mounter-path=/home/kubernetes/containerized_mounter/mounter --cert-dir=/var/lib/kubelet/pki/ --kubeconfig=/var/lib/kubelet/kubeconfig --image-credential-provider-config=/etc/srv/kubernetes/cri_auth_config.yaml --image-credential-provider-bin-dir=/home/kubernetes/bin --max-pods=110 --node-labels=cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=112,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=458,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-placement-group=default-pool,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=c2d,cloud.google.com/private-node=false --volume-plugin-dir=/home/kubernetes/flexvolume --node-status-max-images=25 --container-runtime-endpoint=unix:///run/containerd/containerd.sock --runtime-cgroups=/system.slice/containerd.service --registry-qps=10 --registry-burst=20 --config /home/kubernetes/kubelet-config.yaml --pod-sysctls='net.core.somaxconn=1024,net.ipv4.conf.all.accept_redirects=0,net.ipv4.conf.all.forwarding=1,net.ipv4.conf.all.route_localnet=1,net.ipv4.conf.default.forwarding=1,net.ipv4.ip_forward=1,net.ipv4.tcp_fin_timeout=60,net.ipv4.tcp_keepalive_intvl=60,net.ipv4.tcp_keepalive_probes=5,net.ipv4.tcp_keepalive_time=300,net.ipv4.tcp_rmem=4096 87380 6291456,net.ipv4.tcp_syn_retries=6,net.ipv4.tcp_tw_reuse=0,net.ipv4.tcp_wmem=4096 16384 4194304,net.ipv4.udp_rmem_min=4096,net.ipv4.udp_wmem_min=4096,net.ipv6.conf.all.disable_ipv6=1,net.ipv6.conf.default.accept_ra=0,net.ipv6.conf.default.disable_ipv6=1,net.netfilter.nf_conntrack_generic_timeout=600,net.netfilter.nf_conntrack_tcp_be_liberal=1,net.netfilter.nf_conntrack_tcp_timeout_close_wait=3600,net.netfilter.nf_conntrack_tcp_timeout_established=86400' --cgroup-driver=systemd  --pod-infra-container-image=us-central1-artifactregistry.gcr.io/gke-release/gke-release/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830 --version=v1.30.5-gke.1355000"
+KUBE_COVERAGE_FILE="/var/log/kubelet.cov"
+```

--- a/analysis/test-scaling-governor/aws-dmesg.txt
+++ b/analysis/test-scaling-governor/aws-dmesg.txt
@@ -1,0 +1,1033 @@
+[    0.000000] Linux version 5.10.227-219.884.amzn2.x86_64 (mockbuild@ip-10-0-53-155) (gcc10-gcc (GCC) 10.5.0 20230707 (Red Hat 10.5.0-1), GNU ld version 2.35.2-9.amzn2.0.1) #1 SMP Tue Oct 22 16:38:23 UTC 2024
+[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz-5.10.227-219.884.amzn2.x86_64 root=UUID=a8789b5e-031c-4b41-b906-501fd7c0ef8c ro console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 nvme_core.io_timeout=4294967295 rd.emergency=poweroff rd.shell=0 LANG=en_US.UTF-8 KEYTABLE=us psi=1 clocksource=tsc tsc=reliable
+[    0.000000] KASLR enabled
+[    0.000000] BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
+[    0.000000] BIOS-e820: [mem 0x000000000009fc00-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000000f0000-0x00000000000fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000bffe4fff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bffe5000-0x00000000bfffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000e0000000-0x00000000e03fffff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000fffc0000-0x00000000ffffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000100000000-0x00000017beffffff] usable
+[    0.000000] BIOS-e820: [mem 0x00000017bf000000-0x000000183fffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000001840000000-0x0000002fbeffffff] usable
+[    0.000000] BIOS-e820: [mem 0x0000002fbf000000-0x000000303fffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000003040000000-0x00000047beffffff] usable
+[    0.000000] BIOS-e820: [mem 0x00000047bf000000-0x000000483fffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000004840000000-0x0000005fbeffffff] usable
+[    0.000000] BIOS-e820: [mem 0x0000005fbf000000-0x000000603fffffff] reserved
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] SMBIOS 2.7 present.
+[    0.000000] DMI: Amazon EC2 hpc6a.48xlarge/, BIOS 1.0 10/16/2017
+[    0.000000] Hypervisor detected: KVM
+[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
+[    0.000000] kvm-clock: cpu 0, msr 3d21601001, primary cpu clock
+[    0.000000] kvm-clock: using sched offset of 3019020853 cycles
+[    0.000002] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
+[    0.000004] tsc: Detected 2650.000 MHz processor
+[    0.000496] e820: update [mem 0x00000000-0x00000fff] usable ==> reserved
+[    0.000498] e820: remove [mem 0x000a0000-0x000fffff] usable
+[    0.000503] last_pfn = 0x5fbf000 max_arch_pfn = 0x400000000
+[    0.000548] MTRR default type: write-back
+[    0.000549] MTRR fixed ranges enabled:
+[    0.000550]   00000-9FFFF write-back
+[    0.000550]   A0000-BFFFF uncachable
+[    0.000551]   C0000-FFFFF write-protect
+[    0.000552] MTRR variable ranges enabled:
+[    0.000553]   0 base 0000C0000000 mask FFFFC0000000 uncachable
+[    0.000553]   1 disabled
+[    0.000554]   2 disabled
+[    0.000554]   3 disabled
+[    0.000554]   4 disabled
+[    0.000555]   5 disabled
+[    0.000555]   6 disabled
+[    0.000556]   7 disabled
+[    0.000628] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WP  UC- WT  
+[    0.000683] last_pfn = 0xbffe5 max_arch_pfn = 0x400000000
+[    0.004099] check: Scanning 1 areas for low memory corruption
+[    0.004170] Using GB pages for direct mapping
+[    0.004438] RAMDISK: [mem 0x36871000-0x3742ffff]
+[    0.004518] ACPI: Early table checksum verification disabled
+[    0.004525] ACPI: RSDP 0x00000000000F8F00 000014 (v00 AMAZON)
+[    0.004565] ACPI: RSDT 0x00000000BFFE94C0 000044 (v01 AMAZON AMZNRSDT 00000001 AMZN 00000001)
+[    0.004570] ACPI: WAET 0x00000000BFFEFFC0 000028 (v01 AMAZON AMZNWAET 00000001 AMZN 00000001)
+[    0.004573] ACPI: SLIT 0x00000000BFFEFF40 00006C (v01 AMAZON AMZNSLIT 00000001 AMZN 00000001)
+[    0.004575] ACPI: APIC 0x00000000BFFEFBC0 000366 (v01 AMAZON AMZNAPIC 00000001 AMZN 00000001)
+[    0.004577] ACPI: SRAT 0x00000000BFFEF4C0 0006F8 (v01 AMAZON AMZNSRAT 00000001 AMZN 00000001)
+[    0.004579] ACPI: FACP 0x00000000BFFEF380 000114 (v01 AMAZON AMZNFACP 00000001 AMZN 00000001)
+[    0.004583] ACPI: DSDT 0x00000000BFFEE1C0 00115A (v01 AMAZON AMZNDSDT 00000001 AMZN 00000001)
+[    0.004585] ACPI: FACS 0x00000000000F8EC0 000040
+[    0.004587] ACPI: HPET 0x00000000BFFEF340 000038 (v01 AMAZON AMZNHPET 00000001 AMZN 00000001)
+[    0.004589] ACPI: SSDT 0x00000000BFFE95C0 004BF6 (v01 AMAZON AMZNSSDT 00000001 AMZN 00000001)
+[    0.004592] ACPI: SSDT 0x00000000BFFE9540 00007F (v01 AMAZON AMZNSSDT 00000001 AMZN 00000001)
+[    0.004594] ACPI: Reserving WAET table memory at [mem 0xbffeffc0-0xbffeffe7]
+[    0.004595] ACPI: Reserving SLIT table memory at [mem 0xbffeff40-0xbffeffab]
+[    0.004595] ACPI: Reserving APIC table memory at [mem 0xbffefbc0-0xbffeff25]
+[    0.004596] ACPI: Reserving SRAT table memory at [mem 0xbffef4c0-0xbffefbb7]
+[    0.004597] ACPI: Reserving FACP table memory at [mem 0xbffef380-0xbffef493]
+[    0.004598] ACPI: Reserving DSDT table memory at [mem 0xbffee1c0-0xbffef319]
+[    0.004598] ACPI: Reserving FACS table memory at [mem 0xf8ec0-0xf8eff]
+[    0.004599] ACPI: Reserving HPET table memory at [mem 0xbffef340-0xbffef377]
+[    0.004600] ACPI: Reserving SSDT table memory at [mem 0xbffe95c0-0xbffee1b5]
+[    0.004601] ACPI: Reserving SSDT table memory at [mem 0xbffe9540-0xbffe95be]
+[    0.004616] ACPI: Local APIC address 0xfee00000
+[    0.004641] SRAT: PXM 0 -> APIC 0x00 -> Node 0
+[    0.004642] SRAT: PXM 0 -> APIC 0x01 -> Node 0
+[    0.004643] SRAT: PXM 0 -> APIC 0x02 -> Node 0
+[    0.004644] SRAT: PXM 0 -> APIC 0x03 -> Node 0
+[    0.004644] SRAT: PXM 0 -> APIC 0x04 -> Node 0
+[    0.004645] SRAT: PXM 0 -> APIC 0x05 -> Node 0
+[    0.004646] SRAT: PXM 0 -> APIC 0x06 -> Node 0
+[    0.004646] SRAT: PXM 0 -> APIC 0x07 -> Node 0
+[    0.004647] SRAT: PXM 0 -> APIC 0x08 -> Node 0
+[    0.004647] SRAT: PXM 0 -> APIC 0x09 -> Node 0
+[    0.004648] SRAT: PXM 0 -> APIC 0x0a -> Node 0
+[    0.004649] SRAT: PXM 0 -> APIC 0x0b -> Node 0
+[    0.004649] SRAT: PXM 0 -> APIC 0x0c -> Node 0
+[    0.004650] SRAT: PXM 0 -> APIC 0x0d -> Node 0
+[    0.004651] SRAT: PXM 0 -> APIC 0x0e -> Node 0
+[    0.004651] SRAT: PXM 0 -> APIC 0x0f -> Node 0
+[    0.004652] SRAT: PXM 0 -> APIC 0x10 -> Node 0
+[    0.004653] SRAT: PXM 0 -> APIC 0x11 -> Node 0
+[    0.004653] SRAT: PXM 0 -> APIC 0x12 -> Node 0
+[    0.004654] SRAT: PXM 0 -> APIC 0x13 -> Node 0
+[    0.004654] SRAT: PXM 0 -> APIC 0x14 -> Node 0
+[    0.004655] SRAT: PXM 0 -> APIC 0x15 -> Node 0
+[    0.004656] SRAT: PXM 0 -> APIC 0x16 -> Node 0
+[    0.004656] SRAT: PXM 0 -> APIC 0x17 -> Node 0
+[    0.004657] SRAT: PXM 1 -> APIC 0x20 -> Node 1
+[    0.004658] SRAT: PXM 1 -> APIC 0x21 -> Node 1
+[    0.004658] SRAT: PXM 1 -> APIC 0x22 -> Node 1
+[    0.004659] SRAT: PXM 1 -> APIC 0x23 -> Node 1
+[    0.004659] SRAT: PXM 1 -> APIC 0x24 -> Node 1
+[    0.004660] SRAT: PXM 1 -> APIC 0x25 -> Node 1
+[    0.004661] SRAT: PXM 1 -> APIC 0x26 -> Node 1
+[    0.004661] SRAT: PXM 1 -> APIC 0x27 -> Node 1
+[    0.004662] SRAT: PXM 1 -> APIC 0x28 -> Node 1
+[    0.004663] SRAT: PXM 1 -> APIC 0x29 -> Node 1
+[    0.004663] SRAT: PXM 1 -> APIC 0x2a -> Node 1
+[    0.004664] SRAT: PXM 1 -> APIC 0x2b -> Node 1
+[    0.004664] SRAT: PXM 1 -> APIC 0x2c -> Node 1
+[    0.004665] SRAT: PXM 1 -> APIC 0x2d -> Node 1
+[    0.004666] SRAT: PXM 1 -> APIC 0x2e -> Node 1
+[    0.004666] SRAT: PXM 1 -> APIC 0x2f -> Node 1
+[    0.004667] SRAT: PXM 1 -> APIC 0x30 -> Node 1
+[    0.004668] SRAT: PXM 1 -> APIC 0x31 -> Node 1
+[    0.004668] SRAT: PXM 1 -> APIC 0x32 -> Node 1
+[    0.004669] SRAT: PXM 1 -> APIC 0x33 -> Node 1
+[    0.004669] SRAT: PXM 1 -> APIC 0x34 -> Node 1
+[    0.004670] SRAT: PXM 1 -> APIC 0x35 -> Node 1
+[    0.004671] SRAT: PXM 1 -> APIC 0x36 -> Node 1
+[    0.004671] SRAT: PXM 1 -> APIC 0x37 -> Node 1
+[    0.004672] SRAT: PXM 2 -> APIC 0x40 -> Node 2
+[    0.004673] SRAT: PXM 2 -> APIC 0x41 -> Node 2
+[    0.004673] SRAT: PXM 2 -> APIC 0x42 -> Node 2
+[    0.004674] SRAT: PXM 2 -> APIC 0x43 -> Node 2
+[    0.004674] SRAT: PXM 2 -> APIC 0x44 -> Node 2
+[    0.004675] SRAT: PXM 2 -> APIC 0x45 -> Node 2
+[    0.004676] SRAT: PXM 2 -> APIC 0x46 -> Node 2
+[    0.004676] SRAT: PXM 2 -> APIC 0x47 -> Node 2
+[    0.004677] SRAT: PXM 2 -> APIC 0x48 -> Node 2
+[    0.004678] SRAT: PXM 2 -> APIC 0x49 -> Node 2
+[    0.004678] SRAT: PXM 2 -> APIC 0x4a -> Node 2
+[    0.004679] SRAT: PXM 2 -> APIC 0x4b -> Node 2
+[    0.004679] SRAT: PXM 2 -> APIC 0x4c -> Node 2
+[    0.004680] SRAT: PXM 2 -> APIC 0x4d -> Node 2
+[    0.004681] SRAT: PXM 2 -> APIC 0x4e -> Node 2
+[    0.004681] SRAT: PXM 2 -> APIC 0x4f -> Node 2
+[    0.004682] SRAT: PXM 2 -> APIC 0x50 -> Node 2
+[    0.004683] SRAT: PXM 2 -> APIC 0x51 -> Node 2
+[    0.004683] SRAT: PXM 2 -> APIC 0x52 -> Node 2
+[    0.004684] SRAT: PXM 2 -> APIC 0x53 -> Node 2
+[    0.004684] SRAT: PXM 2 -> APIC 0x54 -> Node 2
+[    0.004685] SRAT: PXM 2 -> APIC 0x55 -> Node 2
+[    0.004686] SRAT: PXM 2 -> APIC 0x56 -> Node 2
+[    0.004686] SRAT: PXM 2 -> APIC 0x57 -> Node 2
+[    0.004687] SRAT: PXM 3 -> APIC 0x60 -> Node 3
+[    0.004688] SRAT: PXM 3 -> APIC 0x61 -> Node 3
+[    0.004688] SRAT: PXM 3 -> APIC 0x62 -> Node 3
+[    0.004689] SRAT: PXM 3 -> APIC 0x63 -> Node 3
+[    0.004689] SRAT: PXM 3 -> APIC 0x64 -> Node 3
+[    0.004690] SRAT: PXM 3 -> APIC 0x65 -> Node 3
+[    0.004691] SRAT: PXM 3 -> APIC 0x66 -> Node 3
+[    0.004691] SRAT: PXM 3 -> APIC 0x67 -> Node 3
+[    0.004692] SRAT: PXM 3 -> APIC 0x68 -> Node 3
+[    0.004693] SRAT: PXM 3 -> APIC 0x69 -> Node 3
+[    0.004693] SRAT: PXM 3 -> APIC 0x6a -> Node 3
+[    0.004694] SRAT: PXM 3 -> APIC 0x6b -> Node 3
+[    0.004694] SRAT: PXM 3 -> APIC 0x6c -> Node 3
+[    0.004695] SRAT: PXM 3 -> APIC 0x6d -> Node 3
+[    0.004696] SRAT: PXM 3 -> APIC 0x6e -> Node 3
+[    0.004696] SRAT: PXM 3 -> APIC 0x6f -> Node 3
+[    0.004697] SRAT: PXM 3 -> APIC 0x70 -> Node 3
+[    0.004697] SRAT: PXM 3 -> APIC 0x71 -> Node 3
+[    0.004698] SRAT: PXM 3 -> APIC 0x72 -> Node 3
+[    0.004699] SRAT: PXM 3 -> APIC 0x73 -> Node 3
+[    0.004699] SRAT: PXM 3 -> APIC 0x74 -> Node 3
+[    0.004700] SRAT: PXM 3 -> APIC 0x75 -> Node 3
+[    0.004701] SRAT: PXM 3 -> APIC 0x76 -> Node 3
+[    0.004701] SRAT: PXM 3 -> APIC 0x77 -> Node 3
+[    0.004704] ACPI: SRAT: Node 0 PXM 0 [mem 0x00000000-0xbfffffff]
+[    0.004705] ACPI: SRAT: Node 0 PXM 0 [mem 0x100000000-0x183fffffff]
+[    0.004706] ACPI: SRAT: Node 1 PXM 1 [mem 0x1840000000-0x303fffffff]
+[    0.004706] ACPI: SRAT: Node 2 PXM 2 [mem 0x3040000000-0x483fffffff]
+[    0.004707] ACPI: SRAT: Node 3 PXM 3 [mem 0x4840000000-0x603fffffff]
+[    0.004752] NUMA: Initialized distance table, cnt=4
+[    0.004754] NUMA: Node 0 [mem 0x00000000-0xbfffffff] + [mem 0x100000000-0x183fffffff] -> [mem 0x00000000-0x183fffffff]
+[    0.004762] NODE_DATA(0) allocated [mem 0x17befde000-0x17beffffff]
+[    0.004809] NODE_DATA(1) allocated [mem 0x2fbefde000-0x2fbeffffff]
+[    0.004857] NODE_DATA(2) allocated [mem 0x47befde000-0x47beffffff]
+[    0.004911] NODE_DATA(3) allocated [mem 0x5fbefdd000-0x5fbeffefff]
+[    0.005325] Zone ranges:
+[    0.005326]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.005328]   DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
+[    0.005329]   Normal   [mem 0x0000000100000000-0x0000005fbeffffff]
+[    0.005330] Movable zone start for each node
+[    0.005332] Early memory node ranges
+[    0.005333]   node   0: [mem 0x0000000000001000-0x000000000009efff]
+[    0.005334]   node   0: [mem 0x0000000000100000-0x00000000bffe4fff]
+[    0.005335]   node   0: [mem 0x0000000100000000-0x00000017beffffff]
+[    0.005342]   node   1: [mem 0x0000001840000000-0x0000002fbeffffff]
+[    0.005348]   node   2: [mem 0x0000003040000000-0x00000047beffffff]
+[    0.005355]   node   3: [mem 0x0000004840000000-0x0000005fbeffffff]
+[    0.005362] Initmem setup node 0 [mem 0x0000000000001000-0x00000017beffffff]
+[    0.005363] On node 0 totalpages: 24637315
+[    0.005364]   DMA zone: 64 pages used for memmap
+[    0.005365]   DMA zone: 21 pages reserved
+[    0.005366]   DMA zone: 3998 pages, LIFO batch:0
+[    0.005367]   DMA32 zone: 12224 pages used for memmap
+[    0.005368]   DMA32 zone: 782309 pages, LIFO batch:63
+[    0.005368]   Normal zone: 372672 pages used for memmap
+[    0.005369]   Normal zone: 23851008 pages, LIFO batch:63
+[    0.005369] Initmem setup node 1 [mem 0x0000001840000000-0x0000002fbeffffff]
+[    0.005370] On node 1 totalpages: 24637440
+[    0.005371]   Normal zone: 384960 pages used for memmap
+[    0.005371]   Normal zone: 24637440 pages, LIFO batch:63
+[    0.005372] Initmem setup node 2 [mem 0x0000003040000000-0x00000047beffffff]
+[    0.005373] On node 2 totalpages: 24637440
+[    0.005373]   Normal zone: 384960 pages used for memmap
+[    0.005374]   Normal zone: 24637440 pages, LIFO batch:63
+[    0.005374] Initmem setup node 3 [mem 0x0000004840000000-0x0000005fbeffffff]
+[    0.005375] On node 3 totalpages: 24637440
+[    0.005376]   Normal zone: 384960 pages used for memmap
+[    0.005376]   Normal zone: 24637440 pages, LIFO batch:63
+[    0.005453] On node 0, zone DMA: 1 pages in unavailable ranges
+[    0.005479] On node 0, zone DMA: 97 pages in unavailable ranges
+[    0.010686] On node 0, zone Normal: 27 pages in unavailable ranges
+[    0.011039] On node 1, zone Normal: 4096 pages in unavailable ranges
+[    0.011392] On node 2, zone Normal: 4096 pages in unavailable ranges
+[    0.011743] On node 3, zone Normal: 4096 pages in unavailable ranges
+[    0.011822] On node 3, zone Normal: 4096 pages in unavailable ranges
+[    0.012247] ACPI: PM-Timer IO Port: 0xb008
+[    0.012250] ACPI: Local APIC address 0xfee00000
+[    0.012266] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
+[    0.012314] IOAPIC[0]: apic_id 0, version 32, address 0xfec00000, GSI 0-23
+[    0.012317] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
+[    0.012319] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.012320] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
+[    0.012321] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
+[    0.012322] ACPI: IRQ5 used by override.
+[    0.012323] ACPI: IRQ9 used by override.
+[    0.012323] ACPI: IRQ10 used by override.
+[    0.012324] ACPI: IRQ11 used by override.
+[    0.012326] Using ACPI (MADT) for SMP configuration information
+[    0.012327] ACPI: HPET id: 0x8086a201 base: 0xfed00000
+[    0.012335] smpboot: Allowing 96 CPUs, 0 hotplug CPUs
+[    0.012364] PM: hibernation: Registered nosave memory: [mem 0x00000000-0x00000fff]
+[    0.012365] PM: hibernation: Registered nosave memory: [mem 0x0009f000-0x0009ffff]
+[    0.012366] PM: hibernation: Registered nosave memory: [mem 0x000a0000-0x000effff]
+[    0.012367] PM: hibernation: Registered nosave memory: [mem 0x000f0000-0x000fffff]
+[    0.012368] PM: hibernation: Registered nosave memory: [mem 0xbffe5000-0xbfffffff]
+[    0.012368] PM: hibernation: Registered nosave memory: [mem 0xc0000000-0xdfffffff]
+[    0.012369] PM: hibernation: Registered nosave memory: [mem 0xe0000000-0xe03fffff]
+[    0.012370] PM: hibernation: Registered nosave memory: [mem 0xe0400000-0xfffbffff]
+[    0.012370] PM: hibernation: Registered nosave memory: [mem 0xfffc0000-0xffffffff]
+[    0.012372] PM: hibernation: Registered nosave memory: [mem 0x17bf000000-0x183fffffff]
+[    0.012373] PM: hibernation: Registered nosave memory: [mem 0x2fbf000000-0x303fffffff]
+[    0.012374] PM: hibernation: Registered nosave memory: [mem 0x47bf000000-0x483fffffff]
+[    0.012376] [mem 0xc0000000-0xdfffffff] available for PCI devices
+[    0.012377] Booting paravirtualized kernel on KVM
+[    0.012380] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645519600211568 ns
+[    0.015675] setup_percpu: NR_CPUS:8192 nr_cpumask_bits:96 nr_cpu_ids:96 nr_node_ids:4
+[    0.017967] percpu: Embedded 62 pages/cpu s217088 r8192 d28672 u262144
+[    0.017975] pcpu-alloc: s217088 r8192 d28672 u262144 alloc=1*2097152
+[    0.017977] pcpu-alloc: [0] 00 01 02 03 04 05 06 07 [0] 08 09 10 11 12 13 14 15 
+[    0.017983] pcpu-alloc: [0] 16 17 18 19 20 21 22 23 [1] 24 25 26 27 28 29 30 31 
+[    0.017989] pcpu-alloc: [1] 32 33 34 35 36 37 38 39 [1] 40 41 42 43 44 45 46 47 
+[    0.017995] pcpu-alloc: [2] 48 49 50 51 52 53 54 55 [2] 56 57 58 59 60 61 62 63 
+[    0.018001] pcpu-alloc: [2] 64 65 66 67 68 69 70 71 [3] 72 73 74 75 76 77 78 79 
+[    0.018007] pcpu-alloc: [3] 80 81 82 83 84 85 86 87 [3] 88 89 90 91 92 93 94 95 
+[    0.018052] kvm-guest: stealtime: cpu 0, msr 1760834080
+[    0.018055] kvm-guest: PV spinlocks disabled, no host support
+[    0.018069] Built 4 zonelists, mobility grouping on.  Total pages: 97009774
+[    0.018070] Policy zone: Normal
+[    0.018071] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-5.10.227-219.884.amzn2.x86_64 root=UUID=a8789b5e-031c-4b41-b906-501fd7c0ef8c ro console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 nvme_core.io_timeout=4294967295 rd.emergency=poweroff rd.shell=0 LANG=en_US.UTF-8 KEYTABLE=us psi=1 clocksource=tsc tsc=reliable
+[    0.018188] Fallback order for Node 0: 0 1 2 3 
+[    0.018189] Fallback order for Node 1: 1 0 3 2 
+[    0.018190] Fallback order for Node 2: 2 3 0 1 
+[    0.018191] Fallback order for Node 3: 3 2 1 0 
+[    0.018711] mem auto-init: stack:off, heap alloc:off, heap free:off
+[    0.095145] Memory: 3591608K/394198540K available (12300K kernel code, 9444K rwdata, 8064K rodata, 2464K init, 18744K bss, 6320504K reserved, 0K cma-reserved)
+[    0.095938] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=96, Nodes=4
+[    0.095994] ftrace: allocating 40163 entries in 157 pages
+[    0.115917] ftrace: allocated 157 pages with 5 groups
+[    0.116262] rcu: Hierarchical RCU implementation.
+[    0.116263] rcu: 	RCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=96.
+[    0.116265] 	Rude variant of Tasks RCU enabled.
+[    0.116266] 	Tracing variant of Tasks RCU enabled.
+[    0.116267] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
+[    0.116268] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=96
+[    0.119707] NR_IRQS: 524544, nr_irqs: 1192, preallocated irqs: 16
+[    0.119930] random: crng init done
+[    0.201982] Console: colour VGA+ 80x25
+[    0.925515] printk: console [tty0] enabled
+[    1.158617] printk: console [ttyS0] enabled
+[    1.161734] mempolicy: Disabling automatic NUMA balancing. Configure with numa_balancing= or the kernel.numa_balancing sysctl
+[    1.168807] ACPI: Core revision 20200925
+[    1.171988] clocksource: hpet: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 30580167144 ns
+[    1.178293] APIC: Switch to symmetric I/O mode setup
+[    1.182051] x2apic enabled
+[    1.184952] Switched APIC routing to physical x2apic.
+[    1.189899] ..TIMER: vector=0x30 apic1=0 pin1=0 apic2=-1 pin2=-1
+[    1.193746] clocksource: tsc-early: mask: 0xffffffffffffffff max_cycles: 0x2632bd58d3e, max_idle_ns: 440795307842 ns
+[    1.200577] Calibrating delay loop (skipped) preset value.. 5300.00 BogoMIPS (lpj=10600000)
+[    1.205192] Last level iTLB entries: 4KB 512, 2MB 512, 4MB 256
+[    1.208575] Last level dTLB entries: 4KB 2048, 2MB 2048, 4MB 1024, 1GB 0
+[    1.212578] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    1.216576] Spectre V2 : Mitigation: Retpolines
+[    1.220574] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    1.224574] Spectre V2 : Spectre v2 / SpectreRSB : Filling RSB on VMEXIT
+[    1.228574] Spectre V2 : Enabling Restricted Speculation for firmware calls
+[    1.232576] Spectre V2 : mitigation: Enabling conditional Indirect Branch Prediction Barrier
+[    1.236576] Speculative Store Bypass: Mitigation: Speculative Store Bypass disabled via prctl and seccomp
+[    1.240581] Speculative Return Stack Overflow: IBPB-extending microcode not applied!
+[    1.244574] Speculative Return Stack Overflow: WARNING: See https://kernel.org/doc/html/latest/admin-guide/hw-vuln/srso.html for mitigation options.
+[    1.244575] Speculative Return Stack Overflow: Mitigation: safe RET, no microcode
+[    1.252594] x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
+[    1.256574] x86/fpu: Supporting XSAVE feature 0x002: 'SSE registers'
+[    1.260575] x86/fpu: Supporting XSAVE feature 0x004: 'AVX registers'
+[    1.264577] x86/fpu: xstate_offset[2]:  576, xstate_sizes[2]:  256
+[    1.268575] x86/fpu: Enabled xstate features 0x7, context size is 832 bytes, using 'standard' format.
+[    1.293222] Freeing SMP alternatives memory: 32K
+[    1.297482] pid_max: default: 98304 minimum: 768
+[    1.300824] LSM: Security Framework initializing
+[    1.304056] Yama: becoming mindful.
+[    1.304595] SELinux:  Initializing.
+[    1.308617] LSM support for eBPF active
+[    1.326708] Dentry cache hash table entries: 16777216 (order: 15, 134217728 bytes, vmalloc)
+[    1.335405] Inode-cache hash table entries: 8388608 (order: 14, 67108864 bytes, vmalloc)
+[    1.336834] Mount-cache hash table entries: 262144 (order: 9, 2097152 bytes, vmalloc)
+[    1.340785] Mountpoint-cache hash table entries: 262144 (order: 9, 2097152 bytes, vmalloc)
+[    1.454374] smpboot: CPU0: AMD EPYC 7R13 Processor (family: 0x19, model: 0x1, stepping: 0x1)
+[    1.456799] Performance Events: Fam17h+ core perfctr, AMD PMU driver.
+[    1.460578] ... version:                0
+[    1.464575] ... bit width:              48
+[    1.468575] ... generic registers:      6
+[    1.471568] ... value mask:             0000ffffffffffff
+[    1.472575] ... max period:             00007fffffffffff
+[    1.476575] ... fixed-purpose events:   0
+[    1.480575] ... event mask:             000000000000003f
+[    1.484762] rcu: Hierarchical SRCU implementation.
+[    1.489743] smp: Bringing up secondary CPUs ...
+[    1.492703] x86: Booting SMP configuration:
+[    1.495762] .... node  #0, CPUs:        #1
+[    1.068661] kvm-clock: cpu 1, msr 3d21601041, secondary cpu clock
+[    1.498175] kvm-guest: stealtime: cpu 1, msr 1760874080
+[    1.504712]   #2
+[    1.068661] kvm-clock: cpu 2, msr 3d21601081, secondary cpu clock
+[    1.505826] kvm-guest: stealtime: cpu 2, msr 17608b4080
+[    1.512710]   #3
+[    1.068661] kvm-clock: cpu 3, msr 3d216010c1, secondary cpu clock
+[    1.513674] kvm-guest: stealtime: cpu 3, msr 17608f4080
+[    1.520709]   #4
+[    1.068661] kvm-clock: cpu 4, msr 3d21601101, secondary cpu clock
+[    1.522258] kvm-guest: stealtime: cpu 4, msr 1760934080
+[    1.528706]   #5
+[    1.068661] kvm-clock: cpu 5, msr 3d21601141, secondary cpu clock
+[    1.532993] kvm-guest: stealtime: cpu 5, msr 1760974080
+[    1.536715]   #6
+[    1.068661] kvm-clock: cpu 6, msr 3d21601181, secondary cpu clock
+[    1.541473] kvm-guest: stealtime: cpu 6, msr 17609b4080
+[    1.548707]   #7
+[    1.068661] kvm-clock: cpu 7, msr 3d216011c1, secondary cpu clock
+[    1.549718] kvm-guest: stealtime: cpu 7, msr 17609f4080
+[    1.556710]   #8
+[    1.068661] kvm-clock: cpu 8, msr 3d21601201, secondary cpu clock
+[    1.558399] kvm-guest: stealtime: cpu 8, msr 1760a34080
+[    1.564826]   #9
+[    1.068661] kvm-clock: cpu 9, msr 3d21601241, secondary cpu clock
+[    1.565904] kvm-guest: stealtime: cpu 9, msr 1760a74080
+[    1.572832]  #10
+[    1.068661] kvm-clock: cpu 10, msr 3d21601281, secondary cpu clock
+[    1.576756] kvm-guest: stealtime: cpu 10, msr 1760ab4080
+[    1.580851]  #11
+[    1.068661] kvm-clock: cpu 11, msr 3d216012c1, secondary cpu clock
+[    1.585923] kvm-guest: stealtime: cpu 11, msr 1760af4080
+[    1.592832]  #12
+[    1.068661] kvm-clock: cpu 12, msr 3d21601301, secondary cpu clock
+[    1.594310] kvm-guest: stealtime: cpu 12, msr 1760b34080
+[    1.600832]  #13
+[    1.068661] kvm-clock: cpu 13, msr 3d21601341, secondary cpu clock
+[    1.602507] kvm-guest: stealtime: cpu 13, msr 1760b74080
+[    1.608830]  #14
+[    1.068661] kvm-clock: cpu 14, msr 3d21601381, secondary cpu clock
+[    1.612955] kvm-guest: stealtime: cpu 14, msr 1760bb4080
+[    1.664837]  #15
+[    1.068661] kvm-clock: cpu 15, msr 3d216013c1, secondary cpu clock
+[    1.668894] kvm-guest: stealtime: cpu 15, msr 1760bf4080
+[    1.672849]  #16
+[    1.068661] kvm-clock: cpu 16, msr 3d21601401, secondary cpu clock
+[    1.678270] kvm-guest: stealtime: cpu 16, msr 1760c34080
+[    1.684839]  #17
+[    1.068661] kvm-clock: cpu 17, msr 3d21601441, secondary cpu clock
+[    1.685871] kvm-guest: stealtime: cpu 17, msr 1760c74080
+[    1.692834]  #18
+[    1.068661] kvm-clock: cpu 18, msr 3d21601481, secondary cpu clock
+[    1.694461] kvm-guest: stealtime: cpu 18, msr 1760cb4080
+[    1.700839]  #19
+[    1.068661] kvm-clock: cpu 19, msr 3d216014c1, secondary cpu clock
+[    1.704937] kvm-guest: stealtime: cpu 19, msr 1760cf4080
+[    1.708865]  #20
+[    1.068661] kvm-clock: cpu 20, msr 3d21601501, secondary cpu clock
+[    1.714276] kvm-guest: stealtime: cpu 20, msr 1760d34080
+[    1.720836]  #21
+[    1.068661] kvm-clock: cpu 21, msr 3d21601541, secondary cpu clock
+[    1.721894] kvm-guest: stealtime: cpu 21, msr 1760d74080
+[    1.728843]  #22
+[    1.068661] kvm-clock: cpu 22, msr 3d21601581, secondary cpu clock
+[    1.730536] kvm-guest: stealtime: cpu 22, msr 1760db4080
+[    1.736841]  #23
+[    1.068661] kvm-clock: cpu 23, msr 3d216015c1, secondary cpu clock
+[    1.740952] kvm-guest: stealtime: cpu 23, msr 1760df4080
+
+[    1.750862] .... node  #1, CPUs:   #24
+[    1.068661] kvm-clock: cpu 24, msr 3d21601601, secondary cpu clock
+[    1.752941] kvm-guest: stealtime: cpu 24, msr 2f60834080
+[    1.760727]  #25
+[    1.068661] kvm-clock: cpu 25, msr 3d21601641, secondary cpu clock
+[    1.761849] kvm-guest: stealtime: cpu 25, msr 2f60874080
+[    1.768838]  #26
+[    1.068661] kvm-clock: cpu 26, msr 3d21601681, secondary cpu clock
+[    1.770323] kvm-guest: stealtime: cpu 26, msr 2f608b4080
+[    1.776847]  #27
+[    1.068661] kvm-clock: cpu 27, msr 3d216016c1, secondary cpu clock
+[    1.778508] kvm-guest: stealtime: cpu 27, msr 2f608f4080
+[    1.784838]  #28
+[    1.068661] kvm-clock: cpu 28, msr 3d21601701, secondary cpu clock
+[    1.789015] kvm-guest: stealtime: cpu 28, msr 2f60934080
+[    1.796641]  #29
+[    1.068661] kvm-clock: cpu 29, msr 3d21601741, secondary cpu clock
+[    1.798282] kvm-guest: stealtime: cpu 29, msr 2f60974080
+[    1.804836]  #30
+[    1.068661] kvm-clock: cpu 30, msr 3d21601781, secondary cpu clock
+[    1.805957] kvm-guest: stealtime: cpu 30, msr 2f609b4080
+[    1.812853]  #31
+[    1.068661] kvm-clock: cpu 31, msr 3d216017c1, secondary cpu clock
+[    1.814522] kvm-guest: stealtime: cpu 31, msr 2f609f4080
+[    1.820842]  #32
+[    1.068661] kvm-clock: cpu 32, msr 3d21601801, secondary cpu clock
+[    1.825673] kvm-guest: stealtime: cpu 32, msr 2f60a34080
+[    1.832839]  #33
+[    1.068661] kvm-clock: cpu 33, msr 3d21601841, secondary cpu clock
+[    1.834289] kvm-guest: stealtime: cpu 33, msr 2f60a74080
+[    1.840843]  #34
+[    1.068661] kvm-clock: cpu 34, msr 3d21601881, secondary cpu clock
+[    1.842384] kvm-guest: stealtime: cpu 34, msr 2f60ab4080
+[    1.848848]  #35
+[    1.068661] kvm-clock: cpu 35, msr 3d216018c1, secondary cpu clock
+[    1.853265] kvm-guest: stealtime: cpu 35, msr 2f60af4080
+[    1.860847]  #36
+[    1.068661] kvm-clock: cpu 36, msr 3d21601901, secondary cpu clock
+[    1.861929] kvm-guest: stealtime: cpu 36, msr 2f60b34080
+[    1.868846]  #37
+[    1.068661] kvm-clock: cpu 37, msr 3d21601941, secondary cpu clock
+[    1.870341] kvm-guest: stealtime: cpu 37, msr 2f60b74080
+[    1.876851]  #38
+[    1.068661] kvm-clock: cpu 38, msr 3d21601981, secondary cpu clock
+[    1.878547] kvm-guest: stealtime: cpu 38, msr 2f60bb4080
+[    1.884846]  #39
+[    1.068661] kvm-clock: cpu 39, msr 3d216019c1, secondary cpu clock
+[    1.889018] kvm-guest: stealtime: cpu 39, msr 2f60bf4080
+[    1.896644]  #40
+[    1.068661] kvm-clock: cpu 40, msr 3d21601a01, secondary cpu clock
+[    1.898407] kvm-guest: stealtime: cpu 40, msr 2f60c34080
+[    1.904844]  #41
+[    1.068661] kvm-clock: cpu 41, msr 3d21601a41, secondary cpu clock
+[    1.905871] kvm-guest: stealtime: cpu 41, msr 2f60c74080
+[    1.912844]  #42
+[    1.068661] kvm-clock: cpu 42, msr 3d21601a81, secondary cpu clock
+[    1.913944] kvm-guest: stealtime: cpu 42, msr 2f60cb4080
+[    1.920846]  #43
+[    1.068661] kvm-clock: cpu 43, msr 3d21601ac1, secondary cpu clock
+[    1.924961] kvm-guest: stealtime: cpu 43, msr 2f60cf4080
+[    1.928865]  #44
+[    1.068661] kvm-clock: cpu 44, msr 3d21601b01, secondary cpu clock
+[    1.933675] kvm-guest: stealtime: cpu 44, msr 2f60d34080
+[    1.940846]  #45
+[    1.068661] kvm-clock: cpu 45, msr 3d21601b41, secondary cpu clock
+[    1.941842] kvm-guest: stealtime: cpu 45, msr 2f60d74080
+[    1.948844]  #46
+[    1.068661] kvm-clock: cpu 46, msr 3d21601b81, secondary cpu clock
+[    1.949895] kvm-guest: stealtime: cpu 46, msr 2f60db4080
+[    1.956845]  #47
+[    1.068661] kvm-clock: cpu 47, msr 3d21601bc1, secondary cpu clock
+[    1.958488] kvm-guest: stealtime: cpu 47, msr 2f60df4080
+
+[    1.968578] .... node  #2, CPUs:   #48
+[    1.068661] kvm-clock: cpu 48, msr 3d21601c01, secondary cpu clock
+[    1.973074] kvm-guest: stealtime: cpu 48, msr 4760834080
+[    1.980869]  #49
+[    1.068661] kvm-clock: cpu 49, msr 3d21601c41, secondary cpu clock
+[    1.981966] kvm-guest: stealtime: cpu 49, msr 4760874080
+[    1.988872]  #50
+[    1.068661] kvm-clock: cpu 50, msr 3d21601c81, secondary cpu clock
+[    1.989979] kvm-guest: stealtime: cpu 50, msr 47608b4080
+[    1.996854]  #51
+[    1.068661] kvm-clock: cpu 51, msr 3d21601cc1, secondary cpu clock
+[    1.998673] kvm-guest: stealtime: cpu 51, msr 47608f4080
+[    2.004855]  #52
+[    1.068661] kvm-clock: cpu 52, msr 3d21601d01, secondary cpu clock
+[    2.008878] kvm-guest: stealtime: cpu 52, msr 4760934080
+[    2.012872]  #53
+[    1.068661] kvm-clock: cpu 53, msr 3d21601d41, secondary cpu clock
+[    2.018243] kvm-guest: stealtime: cpu 53, msr 4760974080
+[    2.024910]  #54
+[    1.068661] kvm-clock: cpu 54, msr 3d21601d81, secondary cpu clock
+[    2.025998] kvm-guest: stealtime: cpu 54, msr 47609b4080
+[    2.032869]  #55
+[    1.068661] kvm-clock: cpu 55, msr 3d21601dc1, secondary cpu clock
+[    2.034028] kvm-guest: stealtime: cpu 55, msr 47609f4080
+[    2.040865]  #56
+[    1.068661] kvm-clock: cpu 56, msr 3d21601e01, secondary cpu clock
+[    2.045774] kvm-guest: stealtime: cpu 56, msr 4760a34080
+[    2.052855]  #57
+[    1.068661] kvm-clock: cpu 57, msr 3d21601e41, secondary cpu clock
+[    2.054622] kvm-guest: stealtime: cpu 57, msr 4760a74080
+[    2.060855]  #58
+[    1.068661] kvm-clock: cpu 58, msr 3d21601e81, secondary cpu clock
+[    2.061951] kvm-guest: stealtime: cpu 58, msr 4760ab4080
+[    2.068879]  #59
+[    1.068661] kvm-clock: cpu 59, msr 3d21601ec1, secondary cpu clock
+[    2.072774] kvm-guest: stealtime: cpu 59, msr 4760af4080
+[    2.076880]  #60
+[    1.068661] kvm-clock: cpu 60, msr 3d21601f01, secondary cpu clock
+[    2.082206] kvm-guest: stealtime: cpu 60, msr 4760b34080
+[    2.088866]  #61
+[    1.068661] kvm-clock: cpu 61, msr 3d21601f41, secondary cpu clock
+[    2.089981] kvm-guest: stealtime: cpu 61, msr 4760b74080
+[    2.096865]  #62
+[    1.068661] kvm-clock: cpu 62, msr 3d21601f81, secondary cpu clock
+[    2.098017] kvm-guest: stealtime: cpu 62, msr 4760bb4080
+[    2.104856]  #63
+[    1.068661] kvm-clock: cpu 63, msr 3d21601fc1, secondary cpu clock
+[    2.109232] kvm-guest: stealtime: cpu 63, msr 4760bf4080
+[    2.116871]  #64
+[    1.068661] kvm-clock: cpu 64, msr 3043132001, secondary cpu clock
+[    2.119029] kvm-guest: stealtime: cpu 64, msr 4760c34080
+[    2.124862]  #65
+[    1.068661] kvm-clock: cpu 65, msr 3043132041, secondary cpu clock
+[    2.125970] kvm-guest: stealtime: cpu 65, msr 4760c74080
+[    2.132859]  #66
+[    1.068661] kvm-clock: cpu 66, msr 3043132081, secondary cpu clock
+[    2.137323] kvm-guest: stealtime: cpu 66, msr 4760cb4080
+[    2.144870]  #67
+[    1.068661] kvm-clock: cpu 67, msr 30431320c1, secondary cpu clock
+[    2.145946] kvm-guest: stealtime: cpu 67, msr 4760cf4080
+[    2.152886]  #68
+[    1.068661] kvm-clock: cpu 68, msr 3043132101, secondary cpu clock
+[    2.154010] kvm-guest: stealtime: cpu 68, msr 4760d34080
+[    2.160854]  #69
+[    1.068661] kvm-clock: cpu 69, msr 3043132141, secondary cpu clock
+[    2.162649] kvm-guest: stealtime: cpu 69, msr 4760d74080
+[    2.168867]  #70
+[    1.068661] kvm-clock: cpu 70, msr 3043132181, secondary cpu clock
+[    2.173025] kvm-guest: stealtime: cpu 70, msr 4760db4080
+[    2.180736]  #71
+[    1.068661] kvm-clock: cpu 71, msr 30431321c1, secondary cpu clock
+[    2.181852] kvm-guest: stealtime: cpu 71, msr 4760df4080
+
+[    2.191345] .... node  #3, CPUs:   #72
+[    1.068661] kvm-clock: cpu 72, msr 3043132201, secondary cpu clock
+[    2.194591] kvm-guest: stealtime: cpu 72, msr 5f60834080
+[    2.200869]  #73
+[    1.068661] kvm-clock: cpu 73, msr 3043132241, secondary cpu clock
+[    2.202681] kvm-guest: stealtime: cpu 73, msr 5f60874080
+[    2.208879]  #74
+[    1.068661] kvm-clock: cpu 74, msr 3043132281, secondary cpu clock
+[    2.212941] kvm-guest: stealtime: cpu 74, msr 5f608b4080
+[    2.220599]  #75
+[    1.068661] kvm-clock: cpu 75, msr 30431322c1, secondary cpu clock
+[    2.221750] kvm-guest: stealtime: cpu 75, msr 5f608f4080
+[    2.228867]  #76
+[    1.068661] kvm-clock: cpu 76, msr 3043132301, secondary cpu clock
+[    2.230653] kvm-guest: stealtime: cpu 76, msr 5f60934080
+[    2.236904]  #77
+[    1.068661] kvm-clock: cpu 77, msr 3043132341, secondary cpu clock
+[    2.237985] kvm-guest: stealtime: cpu 77, msr 5f60974080
+[    2.244868]  #78
+[    1.068661] kvm-clock: cpu 78, msr 3043132381, secondary cpu clock
+[    2.248868] kvm-guest: stealtime: cpu 78, msr 5f609b4080
+[    2.256599]  #79
+[    1.068661] kvm-clock: cpu 79, msr 30431323c1, secondary cpu clock
+[    2.257746] kvm-guest: stealtime: cpu 79, msr 5f609f4080
+[    2.264881]  #80
+[    1.068661] kvm-clock: cpu 80, msr 3043132401, secondary cpu clock
+[    2.267289] kvm-guest: stealtime: cpu 80, msr 5f60a34080
+[    2.272884]  #81
+[    1.068661] kvm-clock: cpu 81, msr 3043132441, secondary cpu clock
+[    2.276794] kvm-guest: stealtime: cpu 81, msr 5f60a74080
+[    2.280887]  #82
+[    1.068661] kvm-clock: cpu 82, msr 3043132481, secondary cpu clock
+[    2.286225] kvm-guest: stealtime: cpu 82, msr 5f60ab4080
+[    2.292865]  #83
+[    1.068661] kvm-clock: cpu 83, msr 30431324c1, secondary cpu clock
+[    2.293961] kvm-guest: stealtime: cpu 83, msr 5f60af4080
+[    2.300872]  #84
+[    1.068661] kvm-clock: cpu 84, msr 3043132501, secondary cpu clock
+[    2.302001] kvm-guest: stealtime: cpu 84, msr 5f60b34080
+[    2.308871]  #85
+[    1.068661] kvm-clock: cpu 85, msr 3043132541, secondary cpu clock
+[    2.313226] kvm-guest: stealtime: cpu 85, msr 5f60b74080
+[    2.320886]  #86
+[    1.068661] kvm-clock: cpu 86, msr 3043132581, secondary cpu clock
+[    2.321987] kvm-guest: stealtime: cpu 86, msr 5f60bb4080
+[    2.328888]  #87
+[    1.068661] kvm-clock: cpu 87, msr 30431325c1, secondary cpu clock
+[    2.330015] kvm-guest: stealtime: cpu 87, msr 5f60bf4080
+[    2.336866]  #88
+[    1.068661] kvm-clock: cpu 88, msr 3043132601, secondary cpu clock
+[    2.340885] kvm-guest: stealtime: cpu 88, msr 5f60c34080
+[    2.348632]  #89
+[    1.068661] kvm-clock: cpu 89, msr 3043132641, secondary cpu clock
+[    2.349784] kvm-guest: stealtime: cpu 89, msr 5f60c74080
+[    2.356865]  #90
+[    1.068661] kvm-clock: cpu 90, msr 3043132681, secondary cpu clock
+[    2.358649] kvm-guest: stealtime: cpu 90, msr 5f60cb4080
+[    2.364878]  #91
+[    1.068661] kvm-clock: cpu 91, msr 30431326c1, secondary cpu clock
+[    2.365996] kvm-guest: stealtime: cpu 91, msr 5f60cf4080
+[    2.372891]  #92
+[    1.068661] kvm-clock: cpu 92, msr 3043132701, secondary cpu clock
+[    2.376807] kvm-guest: stealtime: cpu 92, msr 5f60d34080
+[    2.380899]  #93
+[    1.068661] kvm-clock: cpu 93, msr 3043132741, secondary cpu clock
+[    2.386218] kvm-guest: stealtime: cpu 93, msr 5f60d74080
+[    2.392923]  #94
+[    1.068661] kvm-clock: cpu 94, msr 3043132781, secondary cpu clock
+[    2.394002] kvm-guest: stealtime: cpu 94, msr 5f60db4080
+[    2.400892]  #95
+[    1.068661] kvm-clock: cpu 95, msr 30431327c1, secondary cpu clock
+[    2.402147] kvm-guest: stealtime: cpu 95, msr 5f60df4080
+[    2.409008] smp: Brought up 4 nodes, 96 CPUs
+[    2.412577] smpboot: Max logical packages: 2
+[    2.416582] smpboot: Total of 96 processors activated (508800.00 BogoMIPS)
+[    2.513095] node 0 deferred pages initialised in 84ms
+[    2.515485] node 1 deferred pages initialised in 84ms
+[    2.517012] node 3 deferred pages initialised in 84ms
+[    2.518533] node 2 deferred pages initialised in 84ms
+[    2.540681] devtmpfs: initialized
+[    2.540705] x86/mm: Memory block size: 128MB
+[    2.578030] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
+[    2.584685] futex hash table entries: 32768 (order: 9, 2097152 bytes, vmalloc)
+[    2.589570] NET: Registered protocol family 16
+[    2.640757] DMA: preallocated 4096 KiB GFP_KERNEL pool for atomic allocations
+[    2.644583] DMA: preallocated 4096 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
+[    2.652582] DMA: preallocated 4096 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
+[    2.656586] audit: initializing netlink subsys (disabled)
+[    2.660635] audit: type=2000 audit(1731166645.392:1): state=initialized audit_enabled=0 res=1
+[    2.660764] thermal_sys: Registered thermal governor 'fair_share'
+[    2.668578] thermal_sys: Registered thermal governor 'step_wise'
+[    2.672324] thermal_sys: Registered thermal governor 'user_space'
+[    2.676643] cpuidle: using governor ladder
+[    2.680630] cpuidle: using governor menu
+[    2.689347] ACPI: bus type PCI registered
+[    2.692579] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    2.696858] PCI: Using configuration type 1 for base access
+[    2.700576] PCI: Using configuration type 1 for extended access
+[    2.718410] Kprobes globally optimized
+[    2.720672] HugeTLB registered 1.00 GiB page size, pre-allocated 0 pages
+[    2.724577] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
+[    2.836764] ACPI: Added _OSI(Module Device)
+[    2.840577] ACPI: Added _OSI(Processor Device)
+[    2.843724] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    2.848576] ACPI: Added _OSI(Processor Aggregator Device)
+[    2.852576] ACPI: Added _OSI(Linux-Dell-Video)
+[    2.852576] ACPI: Added _OSI(Linux-Lenovo-NV-HDMI-Audio)
+[    2.856576] ACPI: Added _OSI(Linux-HPI-Hybrid-Graphics)
+[    2.864982] ACPI: 3 ACPI AML tables successfully acquired and loaded
+[    2.876654] ACPI: Interpreter enabled
+[    2.879560] ACPI: (supports S0 S4 S5)
+[    2.880577] ACPI: Using IOAPIC for interrupt routing
+[    2.884597] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    2.892804] ACPI: Enabled 2 GPEs in block 00 to 0F
+[    2.905721] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
+[    2.908583] acpi PNP0A03:00: _OSC: OS supports [ExtendedConfig ASPM ClockPM Segments MSI HPX-Type3]
+[    2.916926] acpiphp: Slot [3] registered
+[    2.920606] acpiphp: Slot [4] registered
+[    2.920606] acpiphp: Slot [5] registered
+[    2.924597] acpiphp: Slot [6] registered
+[    2.927605] acpiphp: Slot [7] registered
+[    2.932597] acpiphp: Slot [8] registered
+[    2.932600] acpiphp: Slot [9] registered
+[    2.936596] acpiphp: Slot [10] registered
+[    2.939611] acpiphp: Slot [11] registered
+[    2.944601] acpiphp: Slot [12] registered
+[    2.944604] acpiphp: Slot [13] registered
+[    2.948596] acpiphp: Slot [14] registered
+[    2.951582] acpiphp: Slot [15] registered
+[    2.956597] acpiphp: Slot [16] registered
+[    2.956606] acpiphp: Slot [17] registered
+[    2.960598] acpiphp: Slot [18] registered
+[    2.963614] acpiphp: Slot [19] registered
+[    2.968596] acpiphp: Slot [20] registered
+[    2.968600] acpiphp: Slot [21] registered
+[    2.972596] acpiphp: Slot [22] registered
+[    2.975608] acpiphp: Slot [23] registered
+[    2.980600] acpiphp: Slot [24] registered
+[    2.980605] acpiphp: Slot [25] registered
+[    2.984595] acpiphp: Slot [26] registered
+[    2.987618] acpiphp: Slot [27] registered
+[    2.992596] acpiphp: Slot [28] registered
+[    2.992600] acpiphp: Slot [29] registered
+[    2.996597] acpiphp: Slot [30] registered
+[    2.999597] acpiphp: Slot [31] registered
+[    3.004586] PCI host bridge to bus 0000:00
+[    3.008605] pci_bus 0000:00: Unknown NUMA node; performance will be reduced
+[    3.012577] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    3.016576] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    3.020576] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    3.024576] pci_bus 0000:00: root bus resource [mem 0xc0000000-0xfebfffff window]
+[    3.028576] pci_bus 0000:00: root bus resource [mem 0x6040000000-0x20603fffffff window]
+[    3.036576] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    3.040714] pci 0000:00:00.0: [8086:1237] type 00 class 0x060000
+[    3.045008] pci 0000:00:01.0: [8086:7000] type 00 class 0x060100
+[    3.048702] pci 0000:00:01.3: [8086:7113] type 00 class 0x000000
+[    3.053229] pci 0000:00:01.3: quirk: [io  0xb000-0xb03f] claimed by PIIX4 ACPI
+[    3.060591] pci 0000:00:01.3: quirk: [io  0xb100-0xb10f] claimed by PIIX4 SMB
+[    3.064633] pci 0000:00:01.3: PIIX4 devres E PIO at fff0-ffff
+[    3.068593] pci 0000:00:01.3: PIIX4 devres F MMIO at ffc00000-ffffffff
+[    3.072590] pci 0000:00:01.3: PIIX4 devres G PIO at fff0-ffff
+[    3.072590] pci 0000:00:01.3: PIIX4 devres H MMIO at ffc00000-ffffffff
+[    3.076591] pci 0000:00:01.3: PIIX4 devres I PIO at fff0-ffff
+[    3.080590] pci 0000:00:01.3: PIIX4 devres J PIO at fff0-ffff
+[    3.084584] pci 0000:00:01.3: quirk_piix4_acpi+0x0/0x170 took 31250 usecs
+[    3.088903] pci 0000:00:03.0: [1d0f:1111] type 00 class 0x030000
+[    3.096575] pci 0000:00:03.0: reg 0x10: [mem 0xf8000000-0xf83fffff pref]
+[    3.108578] pci 0000:00:03.0: reg 0x30: [mem 0xfe800000-0xfe80ffff pref]
+[    3.113145] pci 0000:00:04.0: [1d0f:8061] type 00 class 0x010802
+[    3.124952] pci 0000:00:04.0: reg 0x10: [mem 0xfe810000-0xfe813fff]
+[    3.156947] pci 0000:00:04.0: enabling Extended Tags
+[    3.161320] pci 0000:00:05.0: [1d0f:ec20] type 00 class 0x020000
+[    3.180579] pci 0000:00:05.0: reg 0x10: [mem 0xfe814000-0xfe815fff]
+[    3.193611] pci 0000:00:05.0: reg 0x14: [mem 0xfe816000-0xfe817fff]
+[    3.210115] pci 0000:00:05.0: reg 0x18: [mem 0xf8400000-0xf84fffff pref]
+[    3.253071] pci 0000:00:05.0: enabling Extended Tags
+[    3.260576] pci 0000:00:1f.0: [1d0f:efa1] type 00 class 0x020000
+[    3.277345] pci 0000:00:1f.0: reg 0x10: [mem 0xfe818000-0xfe819fff]
+[    3.297728] pci 0000:00:1f.0: reg 0x14: [mem 0xfe81a000-0xfe81bfff]
+[    3.316577] pci 0000:00:1f.0: reg 0x18: [mem 0xf0000000-0xf7ffffff 64bit pref]
+[    3.337290] pci 0000:00:1f.0: reg 0x20: [mem 0xfe000000-0xfe7fffff 64bit]
+[    3.360613] pci 0000:00:1f.0: enabling Extended Tags
+[    3.365533] ACPI: PCI Interrupt Link [LNKA] (IRQs 5 *10 11)
+[    3.368690] ACPI: PCI Interrupt Link [LNKB] (IRQs 5 *10 11)
+[    3.372687] ACPI: PCI Interrupt Link [LNKC] (IRQs 5 10 *11)
+[    3.376683] ACPI: PCI Interrupt Link [LNKD] (IRQs 5 10 *11)
+[    3.380576] ACPI: PCI Interrupt Link [LNKS] (IRQs *9)
+[    3.396695] iommu: Default domain type: Translated 
+[    3.400732] pci 0000:00:03.0: vgaarb: setting as boot VGA device
+[    3.404573] pci 0000:00:03.0: vgaarb: VGA device added: decodes=io+mem,owns=io+mem,locks=none
+[    3.408587] pci 0000:00:03.0: vgaarb: bridge control possible
+[    3.412576] vgaarb: loaded
+[    3.416645] EDAC MC: Ver: 3.0.0
+[    3.420956] NetLabel: Initializing
+[    3.424577] NetLabel:  domain hash size = 128
+[    3.424577] NetLabel:  protocols = UNLABELED CIPSOv4 CALIPSO
+[    3.428595] NetLabel:  unlabeled traffic allowed by default
+[    3.432576] PCI: Using ACPI for IRQ routing
+[    3.435649] PCI: pci_cache_line_size set to 64 bytes
+[    3.435799] e820: reserve RAM buffer [mem 0x0009fc00-0x0009ffff]
+[    3.435801] e820: reserve RAM buffer [mem 0xbffe5000-0xbfffffff]
+[    3.435803] e820: reserve RAM buffer [mem 0x17bf000000-0x17bfffffff]
+[    3.435804] e820: reserve RAM buffer [mem 0x2fbf000000-0x2fbfffffff]
+[    3.435805] e820: reserve RAM buffer [mem 0x47bf000000-0x47bfffffff]
+[    3.435806] e820: reserve RAM buffer [mem 0x5fbf000000-0x5fbfffffff]
+[    3.436867] hpet0: at MMIO 0xfed00000, IRQs 2, 8, 0, 0, 0, 0, 0, 0
+[    3.440578] hpet0: 8 comparators, 32-bit 62.500000 MHz counter
+[    3.449076] clocksource: Switched to clocksource kvm-clock
+[    3.476431] VFS: Disk quotas dquot_6.6.0
+[    3.479484] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    3.483657] pnp: PnP ACPI init
+[    3.486436] pnp 00:00: Plug and Play ACPI device, IDs PNP0b00 (active)
+[    3.486483] pnp 00:01: Plug and Play ACPI device, IDs PNP0303 (active)
+[    3.486511] pnp 00:02: Plug and Play ACPI device, IDs PNP0f13 (active)
+[    3.486576] pnp 00:03: Plug and Play ACPI device, IDs PNP0400 (active)
+[    3.486635] pnp 00:04: Plug and Play ACPI device, IDs PNP0501 (active)
+[    3.486919] pnp: PnP ACPI: found 5 devices
+[    3.497281] clocksource: acpi_pm: mask: 0xffffff max_cycles: 0xffffff, max_idle_ns: 2085701024 ns
+[    3.503554] NET: Registered protocol family 2
+[    3.506985] IP idents hash table entries: 262144 (order: 9, 2097152 bytes, vmalloc)
+[    3.514047] tcp_listen_portaddr_hash hash table entries: 65536 (order: 8, 1048576 bytes, vmalloc)
+[    3.520710] TCP established hash table entries: 524288 (order: 10, 4194304 bytes, vmalloc)
+[    3.527191] TCP bind hash table entries: 65536 (order: 8, 1048576 bytes, vmalloc)
+[    3.532920] TCP: Hash tables configured (established 524288 bind 65536)
+[    3.537204] MPTCP token hash table entries: 65536 (order: 8, 1572864 bytes, vmalloc)
+[    3.543111] UDP hash table entries: 65536 (order: 9, 2097152 bytes, vmalloc)
+[    3.547466] UDP-Lite hash table entries: 65536 (order: 9, 2097152 bytes, vmalloc)
+[    3.553487] NET: Registered protocol family 1
+[    3.556606] NET: Registered protocol family 44
+[    3.559789] pci_bus 0000:00: resource 4 [io  0x0000-0x0cf7 window]
+[    3.563564] pci_bus 0000:00: resource 5 [io  0x0d00-0xffff window]
+[    3.567350] pci_bus 0000:00: resource 6 [mem 0x000a0000-0x000bffff window]
+[    3.571383] pci_bus 0000:00: resource 7 [mem 0xc0000000-0xfebfffff window]
+[    3.575397] pci_bus 0000:00: resource 8 [mem 0x6040000000-0x20603fffffff window]
+[    3.581082] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
+[    3.584776] pci 0000:00:01.0: Activating ISA DMA hang workarounds
+[    3.588593] pci 0000:00:03.0: Video device with shadowed ROM at [mem 0x000c0000-0x000dffff]
+[    3.594657] PCI: CLS 0 bytes, default 64
+[    3.597712] Trying to unpack rootfs image as initramfs...
+[    3.620613] Freeing initrd memory: 12028K
+[    3.623658] PCI-DMA: Using software bounce buffering for IO (SWIOTLB)
+[    3.627521] software IO TLB: mapped [mem 0x00000000bbfe5000-0x00000000bffe5000] (64MB)
+[    3.641456] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x2632bd58d3e, max_idle_ns: 440795307842 ns
+[    3.648455] clocksource: Switched to clocksource tsc
+[    3.678639] check: Scanning for low memory corruption every 60 seconds
+[    3.689807] Initialise system trusted keyrings
+[    3.693013] Key type blacklist registered
+[    3.696415] workingset: timestamp_bits=36 max_order=27 bucket_order=0
+[    3.701984] zbud: loaded
+[    3.704764] SGI XFS with ACLs, security attributes, quota, no debug enabled
+[    3.711731] Key type asymmetric registered
+[    3.714825] Asymmetric key parser 'x509' registered
+[    3.718160] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 251)
+[    3.771791] io scheduler mq-deadline registered
+[    3.774995] io scheduler kyber registered
+[    3.778067] io scheduler bfq registered
+[    3.785465] shpchp: Standard Hot Plug PCI Controller Driver version: 0.4
+[    3.789569] Monitor-Mwait will be used to enter C-1 state
+[    3.789594] ACPI: \_SB_.CP00: Found 2 idle states
+[    3.793041] ACPI: \_SB_.CP01: Found 2 idle states
+[    3.796455] ACPI: \_SB_.CP02: Found 2 idle states
+[    3.799879] ACPI: \_SB_.CP03: Found 2 idle states
+[    3.803310] ACPI: \_SB_.CP04: Found 2 idle states
+[    3.806739] ACPI: \_SB_.CP05: Found 2 idle states
+[    3.810144] ACPI: \_SB_.CP06: Found 2 idle states
+[    3.813555] ACPI: \_SB_.CP07: Found 2 idle states
+[    3.816985] ACPI: \_SB_.CP08: Found 2 idle states
+[    3.820428] ACPI: \_SB_.CP09: Found 2 idle states
+[    3.823889] ACPI: \_SB_.CP0A: Found 2 idle states
+[    3.827333] ACPI: \_SB_.CP0B: Found 2 idle states
+[    3.830766] ACPI: \_SB_.CP0C: Found 2 idle states
+[    3.834206] ACPI: \_SB_.CP0D: Found 2 idle states
+[    3.837655] ACPI: \_SB_.CP0E: Found 2 idle states
+[    3.841050] ACPI: \_SB_.CP0F: Found 2 idle states
+[    3.844444] ACPI: \_SB_.CP10: Found 2 idle states
+[    3.847863] ACPI: \_SB_.CP11: Found 2 idle states
+[    3.851321] ACPI: \_SB_.CP12: Found 2 idle states
+[    3.854732] ACPI: \_SB_.CP13: Found 2 idle states
+[    3.858128] ACPI: \_SB_.CP14: Found 2 idle states
+[    3.861533] ACPI: \_SB_.CP15: Found 2 idle states
+[    3.864963] ACPI: \_SB_.CP16: Found 2 idle states
+[    3.868370] ACPI: \_SB_.CP17: Found 2 idle states
+[    3.871781] ACPI: \_SB_.CP18: Found 2 idle states
+[    3.875188] ACPI: \_SB_.CP19: Found 2 idle states
+[    3.878609] ACPI: \_SB_.CP1A: Found 2 idle states
+[    3.882007] ACPI: \_SB_.CP1B: Found 2 idle states
+[    3.885438] ACPI: \_SB_.CP1C: Found 2 idle states
+[    3.888867] ACPI: \_SB_.CP1D: Found 2 idle states
+[    3.892282] ACPI: \_SB_.CP1E: Found 2 idle states
+[    3.895674] ACPI: \_SB_.CP1F: Found 2 idle states
+[    3.899120] ACPI: \_SB_.CP20: Found 2 idle states
+[    3.902579] ACPI: \_SB_.CP21: Found 2 idle states
+[    3.905990] ACPI: \_SB_.CP22: Found 2 idle states
+[    3.909430] ACPI: \_SB_.CP23: Found 2 idle states
+[    3.913007] ACPI: \_SB_.CP24: Found 2 idle states
+[    3.916420] ACPI: \_SB_.CP25: Found 2 idle states
+[    3.919842] ACPI: \_SB_.CP26: Found 2 idle states
+[    3.923280] ACPI: \_SB_.CP27: Found 2 idle states
+[    3.926710] ACPI: \_SB_.CP28: Found 2 idle states
+[    3.930156] ACPI: \_SB_.CP29: Found 2 idle states
+[    3.933583] ACPI: \_SB_.CP2A: Found 2 idle states
+[    3.937002] ACPI: \_SB_.CP2B: Found 2 idle states
+[    3.940418] ACPI: \_SB_.CP2C: Found 2 idle states
+[    3.943854] ACPI: \_SB_.CP2D: Found 2 idle states
+[    3.947273] ACPI: \_SB_.CP2E: Found 2 idle states
+[    3.950701] ACPI: \_SB_.CP2F: Found 2 idle states
+[    3.954131] ACPI: \_SB_.CP30: Found 2 idle states
+[    3.957554] ACPI: \_SB_.CP31: Found 2 idle states
+[    3.960960] ACPI: \_SB_.CP32: Found 2 idle states
+[    3.964348] ACPI: \_SB_.CP33: Found 2 idle states
+[    3.967739] ACPI: \_SB_.CP34: Found 2 idle states
+[    3.971147] ACPI: \_SB_.CP35: Found 2 idle states
+[    3.974559] ACPI: \_SB_.CP36: Found 2 idle states
+[    3.977969] ACPI: \_SB_.CP37: Found 2 idle states
+[    3.981365] ACPI: \_SB_.CP38: Found 2 idle states
+[    3.984767] ACPI: \_SB_.CP39: Found 2 idle states
+[    3.988363] ACPI: \_SB_.CP3A: Found 2 idle states
+[    3.991793] ACPI: \_SB_.CP3B: Found 2 idle states
+[    3.995199] ACPI: \_SB_.CP3C: Found 2 idle states
+[    3.998602] ACPI: \_SB_.CP3D: Found 2 idle states
+[    4.002004] ACPI: \_SB_.CP3E: Found 2 idle states
+[    4.005392] ACPI: \_SB_.CP3F: Found 2 idle states
+[    4.008807] ACPI: \_SB_.CP40: Found 2 idle states
+[    4.012177] ACPI: \_SB_.CP41: Found 2 idle states
+[    4.015604] ACPI: \_SB_.CP42: Found 2 idle states
+[    4.019020] ACPI: \_SB_.CP43: Found 2 idle states
+[    4.022410] ACPI: \_SB_.CP44: Found 2 idle states
+[    4.025811] ACPI: \_SB_.CP45: Found 2 idle states
+[    4.029201] ACPI: \_SB_.CP46: Found 2 idle states
+[    4.032609] ACPI: \_SB_.CP47: Found 2 idle states
+[    4.036027] ACPI: \_SB_.CP48: Found 2 idle states
+[    4.039442] ACPI: \_SB_.CP49: Found 2 idle states
+[    4.042844] ACPI: \_SB_.CP4A: Found 2 idle states
+[    4.046244] ACPI: \_SB_.CP4B: Found 2 idle states
+[    4.049638] ACPI: \_SB_.CP4C: Found 2 idle states
+[    4.053019] ACPI: \_SB_.CP4D: Found 2 idle states
+[    4.056419] ACPI: \_SB_.CP4E: Found 2 idle states
+[    4.059808] ACPI: \_SB_.CP4F: Found 2 idle states
+[    4.063191] ACPI: \_SB_.CP50: Found 2 idle states
+[    4.066548] ACPI: \_SB_.CP51: Found 2 idle states
+[    4.069925] ACPI: \_SB_.CP52: Found 2 idle states
+[    4.073298] ACPI: \_SB_.CP53: Found 2 idle states
+[    4.076679] ACPI: \_SB_.CP54: Found 2 idle states
+[    4.080038] ACPI: \_SB_.CP55: Found 2 idle states
+[    4.083422] ACPI: \_SB_.CP56: Found 2 idle states
+[    4.086786] ACPI: \_SB_.CP57: Found 2 idle states
+[    4.090180] ACPI: \_SB_.CP58: Found 2 idle states
+[    4.093566] ACPI: \_SB_.CP59: Found 2 idle states
+[    4.096939] ACPI: \_SB_.CP5A: Found 2 idle states
+[    4.100304] ACPI: \_SB_.CP5B: Found 2 idle states
+[    4.103702] ACPI: \_SB_.CP5C: Found 2 idle states
+[    4.107114] ACPI: \_SB_.CP5D: Found 2 idle states
+[    4.110514] ACPI: \_SB_.CP5E: Found 2 idle states
+[    4.113918] ACPI: \_SB_.CP5F: Found 2 idle states
+[    4.117370] Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
+[    4.121408] 00:04: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+[    4.145097] nvme nvme0: pci function 0000:00:04.0
+[    4.148414] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
+[    4.148979] PCI Interrupt Link [LNKD] enabled at IRQ 11
+[    4.154446] i8042: Warning: Keylock active
+[    4.161932] serio: i8042 KBD port at 0x60,0x64 irq 1
+[    4.164957] nvme nvme0: 2/0/0 default/read/poll queues
+[    4.165320] serio: i8042 AUX port at 0x60,0x64 irq 12
+[    4.172173] rtc_cmos 00:00: RTC can wake from S4
+[    4.176501] rtc_cmos 00:00: registered as rtc0
+[    4.180199] rtc_cmos 00:00: setting system clock to 2024-11-09T15:37:27 UTC (1731166647)
+[    4.180622] GPT:Primary header thinks Alt. header is not at the end of the disk.
+[    4.186168] rtc_cmos 00:00: alarms up to one day, 114 bytes nvram
+[    4.191797] GPT:8388607 != 314572799
+[    4.195597] hid: raw HID events driver (C) Jiri Kosina
+[    4.198443] GPT:Alternate GPT header not at the end of the disk.
+[    4.198444] GPT:8388607 != 314572799
+[    4.198445] GPT: Use GNU Parted to correct GPT errors.
+[    4.198450]  nvme0n1: p1 p128
+[    4.202180] NET: Registered protocol family 10
+[    4.224202] Segment Routing with IPv6
+[    4.227202] NET: Registered protocol family 17
+[    4.246004] IPI shorthand broadcast: enabled
+[    4.249319] sched_clock: Marking stable (3184618167, 1064661571)->(4300577059, -51297321)
+[    4.255793] registered taskstats version 1
+[    4.258881] Loading compiled-in X.509 certificates
+[    4.264299] Loaded X.509 cert 'Build time autogenerated kernel key: 007d3be948c0f701e89eef458e999e6a501aa99a'
+[    4.270952] zswap: loaded using pool lzo/zbud
+[    4.274993] Key type .fscrypt registered
+[    4.278020] Key type fscrypt-provisioning registered
+[    4.281421] ima: No TPM chip found, activating TPM-bypass!
+[    4.284991] ima: Allocated hash algorithm: sha1
+[    4.288200] ima: No architecture policies found
+[    4.291746] clk: Disabling unused clocks
+[    4.296990] Freeing unused decrypted memory: 2036K
+[    4.300886] Freeing unused kernel image (initmem) memory: 2464K
+[    4.328718] Write protecting the kernel read-only data: 22528k
+[    4.334076] Freeing unused kernel image (text/rodata gap) memory: 2032K
+[    4.338406] Freeing unused kernel image (rodata/data gap) memory: 128K
+[    4.342425] Run /init as init process
+[    4.345306]   with arguments:
+[    4.345307]     /init
+[    4.345308]   with environment:
+[    4.345309]     HOME=/
+[    4.345309]     TERM=linux
+[    4.345310]     BOOT_IMAGE=/boot/vmlinuz-5.10.227-219.884.amzn2.x86_64
+[    4.345311]     biosdevname=0
+[    4.345312]     LANG=en_US.UTF-8
+[    4.345313]     KEYTABLE=us
+[    4.349755] systemd[1]: systemd 219 running in system mode. (+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 -SECCOMP +BLKID +ELFUTILS +KMOD +IDN)
+[    4.360784] systemd[1]: Detected virtualization amazon.
+[    4.364250] systemd[1]: Detected architecture x86-64.
+[    4.367681] systemd[1]: Running in initial RAM disk.
+[    4.372739] systemd[1]: No hostname configured.
+[    4.376210] systemd[1]: Set hostname to <localhost>.
+[    4.379628] systemd[1]: Initializing machine ID from VM UUID.
+[    4.411981] systemd[1]: Reached target Swap.
+[    4.416127] systemd[1]: Reached target Local File Systems.
+[    4.420864] systemd[1]: Reached target Timers.
+[    4.614162] XFS (nvme0n1p1): Mounting V5 Filesystem
+[    4.705748] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input0
+[    6.441893] XFS (nvme0n1p1): Ending clean mount
+[    6.621557] systemd-journald[2198]: Received SIGTERM from PID 1 (systemd).
+[    6.649573] printk: systemd: 17 output lines suppressed due to ratelimiting
+[    6.833937] SELinux:  Runtime disable is deprecated, use selinux=0 on the kernel cmdline.
+[    6.839907] SELinux:  Disabled at runtime.
+[    6.916748] audit: type=1404 audit(1731166650.236:2): enforcing=0 old_enforcing=0 auid=4294967295 ses=4294967295 enabled=0 old-enabled=1 lsm=selinux res=1
+[    7.621228] xfs filesystem being remounted at / supports timestamps until 2038-01-19 (0x7fffffff)
+[    7.669471] systemd-journald[6470]: Received request to flush runtime journal from PID 1
+[    7.804000] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
+[    7.815678] Bridge firewalling registered
+[    7.831854] pps_core: LinuxPPS API ver. 1 registered
+[    7.835260] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+[    7.903243] PTP clock support registered
+[    7.907899] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input3
+[    7.918735] cryptd: max_cpu_qlen set to 1000
+[    7.923089] input: ImPS/2 Generic Wheel Mouse as /devices/platform/i8042/serio1/input/input4
+[    7.932038] Elastic Fabric Adapter (EFA) v2.8.0a
+[    7.932717] ACPI: Power Button [PWRF]
+[    7.938456] input: Sleep Button as /devices/LNXSYSTM:00/LNXSLPBN:00/input/input5
+[    7.944351] ACPI: Sleep Button [SLPF]
+[    7.949979] AVX2 version of gcm_enc/dec engaged.
+[    7.950099] ena 0000:00:05.0: Elastic Network Adapter (ENA) v2.13.0g
+[    7.953352] AES CTR mode by8 optimization enabled
+[    7.984853] ena 0000:00:05.0: ENA device version: 0.10
+[    7.988338] ena 0000:00:05.0: ENA controller version: 0.0.1 implementation version 1
+[    8.054658] efa 0000:00:1f.0: Setup irq:27 name:efa-mgmnt@pci:0000:00:1f.0
+[    8.072686] ena 0000:00:05.0: Forcing large headers and decreasing maximum TX queue size to 512
+[    8.078927] ena 0000:00:05.0: ENA Large LLQ is enabled
+[    8.083306] mousedev: PS/2 mouse device common for all mice
+[    8.089484] efa 0000:00:1f.0 efa_0: IB device registered
+[    8.092507] ena 0000:00:05.0: Elastic Network Adapter (ENA) found at mem fe814000, mac addr 06:40:d7:75:df:61
+[    8.495733] RPC: Registered named UNIX socket transport module.
+[    8.499496] RPC: Registered udp transport module.
+[    8.502761] RPC: Registered tcp transport module.
+[    8.506036] RPC: Registered tcp NFSv4.1 backchannel transport module.
+[    9.826156] ena 0000:00:05.0 eth0: Local page cache is disabled for less than 16 channels
+[   37.514519] efa 0000:00:1f.0 efa_0: Unregister ib device
+[   57.967617] Elastic Fabric Adapter (EFA) v2.8.0a
+[   58.085911] efa 0000:00:1f.0: Setup irq:27 name:efa-mgmnt@pci:0000:00:1f.0
+[   58.122022] efa 0000:00:1f.0 efa_0: IB device registered
+[  101.129251] efa 0000:00:1f.0 rdmap0s31: Unregister ib device
+[  101.309262] efa: loading out-of-tree module taints kernel.
+[  101.312905] efa: module verification failed: signature and/or required key missing - tainting kernel
+[  101.321394] Elastic Fabric Adapter (EFA) v2.13.0g
+[  101.440847] efa 0000:00:1f.0: Setup irq:27 name:efa-mgmnt@pci:0000:00:1f.0
+[  101.477294] efa 0000:00:1f.0 efa_0: IB device registered
+[  108.433977] clocksource: Switched to clocksource kvm-clock
+[  112.526111] bpfilter: Loaded bpfilter_umh pid 53273
+[  112.526298] Started bpfilter
+[  119.722384] IPv6: ADDRCONF(NETDEV_CHANGE): eni4132b30d3ca: link becomes ready
+[  119.725280] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[  119.727955] IPv6: ADDRCONF(NETDEV_CHANGE): eni664a7a2bb42: link becomes ready
+[  119.730802] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[  123.232475] pci 0000:00:06.0: [1d0f:ec20] type 00 class 0x020000
+[  123.235159] pci 0000:00:06.0: reg 0x10: [mem 0x00000000-0x00001fff]
+[  123.237555] pci 0000:00:06.0: reg 0x14: [mem 0x00000000-0x00001fff]
+[  123.240003] pci 0000:00:06.0: reg 0x18: [mem 0x00000000-0x000fffff pref]
+[  123.242706] pci 0000:00:06.0: enabling Extended Tags
+[  123.245415] pci 0000:00:06.0: BAR 2: assigned [mem 0xc0000000-0xc00fffff pref]
+[  123.248142] pci 0000:00:06.0: BAR 0: assigned [mem 0xc0100000-0xc0101fff]
+[  123.250719] pci 0000:00:06.0: BAR 1: assigned [mem 0xc0102000-0xc0103fff]
+[  123.253339] ena 0000:00:06.0: enabling device (0000 -> 0002)
+[  123.266323] ena 0000:00:06.0: ENA device version: 0.10
+[  123.268647] ena 0000:00:06.0: ENA controller version: 0.0.1 implementation version 1
+[  123.366190] ena 0000:00:06.0: Forcing large headers and decreasing maximum TX queue size to 512
+[  123.371051] ena 0000:00:06.0: ENA Large LLQ is enabled
+[  123.388636] ena 0000:00:06.0: Elastic Network Adapter (ENA) found at mem c0100000, mac addr 06:0c:1e:75:25:9b
+[  127.052247] ena 0000:00:06.0 eth1: Local page cache is disabled for less than 16 channels

--- a/analysis/test-scaling-governor/eks-config.yaml
+++ b/analysis/test-scaling-governor/eks-config.yaml
@@ -1,0 +1,26 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: scaling-governor
+  region: us-east-2
+  version: "1.27"
+
+availabilityZones: ["us-east-2b", "us-east-2c"]
+managedNodeGroups:
+  - name: workers
+    availabilityZones: ["us-east-2b"]
+    instanceType: hpc6a.48xlarge
+    # Defaults to 80, this in GB. 80 is too small to support installing EFA
+    volumeSize: 150
+    # This will default to gp3 and you'll wait 30+ minutes and it will fail
+    volumeType: gp2
+    minSize: 2
+    maxSize: 2
+    efaEnabled: true
+    placement:
+      groupName: performance-study
+    labels: { "flux-operator": "true" }
+    ssh:
+      allow: true
+      publicKeyPath: ~/.ssh/id_eks.pub

--- a/analysis/test-scaling-governor/gke-dmesg.txt
+++ b/analysis/test-scaling-governor/gke-dmesg.txt
@@ -1,0 +1,579 @@
+[    0.000000] Linux version 6.1.100+ (builder@fad4ac6e31ad) (Chromium OS 16.0_pre484197_p20230405-r10 clang version 16.0.0 (/var/tmp/portage/sys-devel/llvm-16.0_pre484197_p20230405-r10/work/llvm-16.0_pre484197_p20230405/clang 2916b99182752b1aece8cc4479d8d6a20b5e02da), LLD 16.0.0) #1 SMP PREEMPT_DYNAMIC Sun Sep 29 16:26:42 UTC 2024
+[    0.000000] Command line: BOOT_IMAGE=/syslinux/vmlinuz.A init=/usr/lib/systemd/systemd rootwait ro noresume loglevel=7 console=tty1 console=ttyS0,115200 security=apparmor virtio_net.napi_tx=1 nmi_watchdog=0 csm.disabled=0 csm.pipe.enabled=1 csm.config.enabled=1 ,firmware firmware_class.path=/home/kubernetes/bin/nvidia/firmware module.sig_enforce=0 dm_verity.error_behavior=3 dm_verity.max_bios=-1 dm_verity.dev_wait=1 i915.modeset=1 cros_efi cos.disable_systemd_route_mgmt modules-load=vfio-pci root=/dev/dm-0 "dm-mod.create=vroot,,,ro,0 4077568 verity 0 PARTUUID=1CFF1596-0A57-9A43-A7C7-9C3E9ACFBA0F PARTUUID=1CFF1596-0A57-9A43-A7C7-9C3E9ACFBA0F 4096 4096 509696 509696 sha256 76e7ffc53ac6c75c8a10b1bf13ac4abee89314c401a9e9d99f8d514d452d0a6d 107fd67eb7fac9045e19b861d3be2299e57956e453a9888f2e153c2dad8729e6" intel_iommu=on,sm_on
+[    0.000000] [Firmware Bug]: TSC doesn't count with P0 frequency!
+[    0.000000] BIOS-provided physical RAM map:
+[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x0000000000000fff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000001000-0x0000000000054fff] usable
+[    0.000000] BIOS-e820: [mem 0x0000000000055000-0x000000000005ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000060000-0x0000000000097fff] usable
+[    0.000000] BIOS-e820: [mem 0x0000000000098000-0x000000000009ffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000000100000-0x00000000bf6ecfff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bf6ed000-0x00000000bf96cfff] reserved
+[    0.000000] BIOS-e820: [mem 0x00000000bf96d000-0x00000000bf97efff] ACPI data
+[    0.000000] BIOS-e820: [mem 0x00000000bf97f000-0x00000000bf9fefff] ACPI NVS
+[    0.000000] BIOS-e820: [mem 0x00000000bf9ff000-0x00000000bffdffff] usable
+[    0.000000] BIOS-e820: [mem 0x00000000bffe0000-0x00000000bfffffff] reserved
+[    0.000000] BIOS-e820: [mem 0x0000000100000000-0x000000703fffffff] usable
+[    0.000000] NX (Execute Disable) protection: active
+[    0.000000] efi: EFI v2.70 by EDK II
+[    0.000000] efi: TPMFinalLog=0xbf9f7000 ACPI=0xbf97e000 ACPI 2.0=0xbf97e014 SMBIOS=0xbf7e8000 MOKvar=0xbf7e5000 RNG=0xbf972018 TPMEventLog=0xbce8a018 
+[    0.000000] SMBIOS 2.4 present.
+[    0.000000] DMI: Google Google Compute Engine/Google Compute Engine, BIOS Google 09/13/2024
+[    0.000000] Hypervisor detected: KVM
+[    0.000000] kvm-clock: Using msrs 4b564d01 and 4b564d00
+[    0.000001] kvm-clock: using sched offset of 5465031534 cycles
+[    0.000001] clocksource: kvm-clock: mask: 0xffffffffffffffff max_cycles: 0x1cd42e4dffb, max_idle_ns: 881590591483 ns
+[    0.000003] tsc: Detected 3049.998 MHz processor
+[    0.000008] e820: update [mem 0x00000000-0x00000fff] usable ==> reserved
+[    0.000010] e820: remove [mem 0x000a0000-0x000fffff] usable
+[    0.000014] last_pfn = 0x7040000 max_arch_pfn = 0x400000000
+[    0.000059] x86/PAT: Configuration [0-7]: WB  WC  UC- UC  WB  WP  UC- WT  
+[    0.000067] last_pfn = 0xbffe0 max_arch_pfn = 0x400000000
+[    0.003457] Using GB pages for direct mapping
+[    0.003613] Secure boot disabled
+[    0.003614] ACPI: Early table checksum verification disabled
+[    0.003616] ACPI: RSDP 0x00000000BF97E014 000024 (v02 Google)
+[    0.003619] ACPI: XSDT 0x00000000BF97D0E8 00005C (v01 Google GOOGFACP 00000001      01000013)
+[    0.003622] ACPI: FACP 0x00000000BF978000 0000F4 (v02 Google GOOGFACP 00000001 GOOG 00000001)
+[    0.003626] ACPI: DSDT 0x00000000BF979000 001A64 (v01 Google GOOGDSDT 00000001 GOOG 00000001)
+[    0.003628] ACPI: FACS 0x00000000BF9F0000 000040
+[    0.003629] ACPI: SSDT 0x00000000BF97C000 000316 (v02 GOOGLE Tpm2Tabl 00001000 INTL 20240322)
+[    0.003631] ACPI: TPM2 0x00000000BF97B000 000034 (v04 GOOGLE          00000001 GOOG 00000001)
+[    0.003633] ACPI: SRAT 0x00000000BF977000 000450 (v03 Google GOOGSRAT 00000001 GOOG 00000001)
+[    0.003635] ACPI: APIC 0x00000000BF976000 000226 (v05 Google GOOGAPIC 00000001 GOOG 00000001)
+[    0.003637] ACPI: SSDT 0x00000000BF974000 001F7A (v01 Google GOOGSSDT 00000001 GOOG 00000001)
+[    0.003639] ACPI: WAET 0x00000000BF973000 000028 (v01 Google GOOGWAET 00000001 GOOG 00000001)
+[    0.003640] ACPI: Reserving FACP table memory at [mem 0xbf978000-0xbf9780f3]
+[    0.003641] ACPI: Reserving DSDT table memory at [mem 0xbf979000-0xbf97aa63]
+[    0.003642] ACPI: Reserving FACS table memory at [mem 0xbf9f0000-0xbf9f003f]
+[    0.003643] ACPI: Reserving SSDT table memory at [mem 0xbf97c000-0xbf97c315]
+[    0.003643] ACPI: Reserving TPM2 table memory at [mem 0xbf97b000-0xbf97b033]
+[    0.003644] ACPI: Reserving SRAT table memory at [mem 0xbf977000-0xbf97744f]
+[    0.003645] ACPI: Reserving APIC table memory at [mem 0xbf976000-0xbf976225]
+[    0.003645] ACPI: Reserving SSDT table memory at [mem 0xbf974000-0xbf975f79]
+[    0.003646] ACPI: Reserving WAET table memory at [mem 0xbf973000-0xbf973027]
+[    0.003677] SRAT: PXM 0 -> APIC 0x00 -> Node 0
+[    0.003679] SRAT: PXM 0 -> APIC 0x01 -> Node 0
+[    0.003679] SRAT: PXM 0 -> APIC 0x02 -> Node 0
+[    0.003680] SRAT: PXM 0 -> APIC 0x03 -> Node 0
+[    0.003680] SRAT: PXM 0 -> APIC 0x04 -> Node 0
+[    0.003681] SRAT: PXM 0 -> APIC 0x05 -> Node 0
+[    0.003681] SRAT: PXM 0 -> APIC 0x06 -> Node 0
+[    0.003682] SRAT: PXM 0 -> APIC 0x07 -> Node 0
+[    0.003682] SRAT: PXM 0 -> APIC 0x08 -> Node 0
+[    0.003682] SRAT: PXM 0 -> APIC 0x09 -> Node 0
+[    0.003683] SRAT: PXM 0 -> APIC 0x0a -> Node 0
+[    0.003683] SRAT: PXM 0 -> APIC 0x0b -> Node 0
+[    0.003684] SRAT: PXM 0 -> APIC 0x0c -> Node 0
+[    0.003684] SRAT: PXM 0 -> APIC 0x0d -> Node 0
+[    0.003685] SRAT: PXM 0 -> APIC 0x0e -> Node 0
+[    0.003685] SRAT: PXM 0 -> APIC 0x0f -> Node 0
+[    0.003686] SRAT: PXM 0 -> APIC 0x10 -> Node 0
+[    0.003686] SRAT: PXM 0 -> APIC 0x11 -> Node 0
+[    0.003687] SRAT: PXM 0 -> APIC 0x12 -> Node 0
+[    0.003687] SRAT: PXM 0 -> APIC 0x13 -> Node 0
+[    0.003688] SRAT: PXM 0 -> APIC 0x14 -> Node 0
+[    0.003688] SRAT: PXM 0 -> APIC 0x15 -> Node 0
+[    0.003689] SRAT: PXM 0 -> APIC 0x16 -> Node 0
+[    0.003689] SRAT: PXM 0 -> APIC 0x17 -> Node 0
+[    0.003690] SRAT: PXM 0 -> APIC 0x18 -> Node 0
+[    0.003690] SRAT: PXM 0 -> APIC 0x19 -> Node 0
+[    0.003691] SRAT: PXM 0 -> APIC 0x1a -> Node 0
+[    0.003691] SRAT: PXM 0 -> APIC 0x1b -> Node 0
+[    0.003692] SRAT: PXM 1 -> APIC 0x20 -> Node 1
+[    0.003692] SRAT: PXM 1 -> APIC 0x21 -> Node 1
+[    0.003693] SRAT: PXM 1 -> APIC 0x22 -> Node 1
+[    0.003693] SRAT: PXM 1 -> APIC 0x23 -> Node 1
+[    0.003694] SRAT: PXM 1 -> APIC 0x24 -> Node 1
+[    0.003694] SRAT: PXM 1 -> APIC 0x25 -> Node 1
+[    0.003695] SRAT: PXM 1 -> APIC 0x26 -> Node 1
+[    0.003695] SRAT: PXM 1 -> APIC 0x27 -> Node 1
+[    0.003696] SRAT: PXM 1 -> APIC 0x28 -> Node 1
+[    0.003696] SRAT: PXM 1 -> APIC 0x29 -> Node 1
+[    0.003697] SRAT: PXM 1 -> APIC 0x2a -> Node 1
+[    0.003697] SRAT: PXM 1 -> APIC 0x2b -> Node 1
+[    0.003697] SRAT: PXM 1 -> APIC 0x2c -> Node 1
+[    0.003698] SRAT: PXM 1 -> APIC 0x2d -> Node 1
+[    0.003698] SRAT: PXM 1 -> APIC 0x2e -> Node 1
+[    0.003699] SRAT: PXM 1 -> APIC 0x2f -> Node 1
+[    0.003699] SRAT: PXM 1 -> APIC 0x30 -> Node 1
+[    0.003700] SRAT: PXM 1 -> APIC 0x31 -> Node 1
+[    0.003700] SRAT: PXM 1 -> APIC 0x32 -> Node 1
+[    0.003701] SRAT: PXM 1 -> APIC 0x33 -> Node 1
+[    0.003701] SRAT: PXM 1 -> APIC 0x34 -> Node 1
+[    0.003702] SRAT: PXM 1 -> APIC 0x35 -> Node 1
+[    0.003702] SRAT: PXM 1 -> APIC 0x36 -> Node 1
+[    0.003703] SRAT: PXM 1 -> APIC 0x37 -> Node 1
+[    0.003703] SRAT: PXM 1 -> APIC 0x38 -> Node 1
+[    0.003704] SRAT: PXM 1 -> APIC 0x39 -> Node 1
+[    0.003704] SRAT: PXM 1 -> APIC 0x3a -> Node 1
+[    0.003705] SRAT: PXM 1 -> APIC 0x3b -> Node 1
+[    0.003706] ACPI: SRAT: Node 0 PXM 0 [mem 0x00000000-0x0009ffff]
+[    0.003707] ACPI: SRAT: Node 0 PXM 0 [mem 0x00100000-0xbfffffff]
+[    0.003708] ACPI: SRAT: Node 0 PXM 0 [mem 0x100000000-0x383fffffff]
+[    0.003709] ACPI: SRAT: Node 1 PXM 1 [mem 0x3840000000-0x703fffffff]
+[    0.003711] NUMA: Node 0 [mem 0x00000000-0x0009ffff] + [mem 0x00100000-0xbfffffff] -> [mem 0x00000000-0xbfffffff]
+[    0.003713] NUMA: Node 0 [mem 0x00000000-0xbfffffff] + [mem 0x100000000-0x383fffffff] -> [mem 0x00000000-0x383fffffff]
+[    0.003716] NODE_DATA(0) allocated [mem 0x383fffa000-0x383fffffff]
+[    0.003724] NODE_DATA(1) allocated [mem 0x703fffa000-0x703fffffff]
+[    0.003998] Zone ranges:
+[    0.003999]   DMA      [mem 0x0000000000001000-0x0000000000ffffff]
+[    0.004000]   DMA32    [mem 0x0000000001000000-0x00000000ffffffff]
+[    0.004001]   Normal   [mem 0x0000000100000000-0x000000703fffffff]
+[    0.004003]   Device   empty
+[    0.004003] Movable zone start for each node
+[    0.004004] Early memory node ranges
+[    0.004004]   node   0: [mem 0x0000000000001000-0x0000000000054fff]
+[    0.004005]   node   0: [mem 0x0000000000060000-0x0000000000097fff]
+[    0.004006]   node   0: [mem 0x0000000000100000-0x00000000bf6ecfff]
+[    0.004007]   node   0: [mem 0x00000000bf9ff000-0x00000000bffdffff]
+[    0.004007]   node   0: [mem 0x0000000100000000-0x000000383fffffff]
+[    0.004018]   node   1: [mem 0x0000003840000000-0x000000703fffffff]
+[    0.004028] Initmem setup node 0 [mem 0x0000000000001000-0x000000383fffffff]
+[    0.004030] Initmem setup node 1 [mem 0x0000003840000000-0x000000703fffffff]
+[    0.004035] On node 0, zone DMA: 1 pages in unavailable ranges
+[    0.004037] On node 0, zone DMA: 11 pages in unavailable ranges
+[    0.004067] On node 0, zone DMA: 104 pages in unavailable ranges
+[    0.009972] On node 0, zone DMA32: 786 pages in unavailable ranges
+[    0.010242] On node 0, zone Normal: 32 pages in unavailable ranges
+[    0.046066] ACPI: LAPIC_NMI (acpi_id[0xff] dfl dfl lint[0x1])
+[    0.046101] IOAPIC[0]: apic_id 0, version 17, address 0xfec00000, GSI 0-23
+[    0.046103] ACPI: INT_SRC_OVR (bus 0 bus_irq 5 global_irq 5 high level)
+[    0.046104] ACPI: INT_SRC_OVR (bus 0 bus_irq 9 global_irq 9 high level)
+[    0.046105] ACPI: INT_SRC_OVR (bus 0 bus_irq 10 global_irq 10 high level)
+[    0.046106] ACPI: INT_SRC_OVR (bus 0 bus_irq 11 global_irq 11 high level)
+[    0.046109] ACPI: Using ACPI (MADT) for SMP configuration information
+[    0.046112] smpboot: Allowing 56 CPUs, 0 hotplug CPUs
+[    0.046126] [mem 0xc0000000-0xffffffff] available for PCI devices
+[    0.046127] Booting paravirtualized kernel on KVM
+[    0.046129] clocksource: refined-jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 1910969940391419 ns
+[    0.049959] setup_percpu: NR_CPUS:512 nr_cpumask_bits:56 nr_cpu_ids:56 nr_node_ids:2
+[    0.051286] percpu: Embedded 62 pages/cpu s217088 r8192 d28672 u262144
+[    0.051292] pcpu-alloc: s217088 r8192 d28672 u262144 alloc=1*2097152
+[    0.051294] pcpu-alloc: [0] 00 01 02 03 04 05 06 07 [0] 08 09 10 11 12 13 14 15 
+[    0.051300] pcpu-alloc: [0] 16 17 18 19 20 21 22 23 [0] 24 25 26 27 -- -- -- -- 
+[    0.051306] pcpu-alloc: [1] 28 29 30 31 32 33 34 35 [1] 36 37 38 39 40 41 42 43 
+[    0.051311] pcpu-alloc: [1] 44 45 46 47 48 49 50 51 [1] 52 53 54 55 -- -- -- -- 
+[    0.051330] kvm-guest: PV spinlocks disabled, no host support
+[    0.051332] Fallback order for Node 0: 0 1 
+[    0.051334] Fallback order for Node 1: 1 0 
+[    0.051336] Built 2 zonelists, mobility grouping on.  Total pages: 115602424
+[    0.051337] Policy zone: Normal
+[    0.051338] Kernel command line: BOOT_IMAGE=/syslinux/vmlinuz.A init=/usr/lib/systemd/systemd rootwait ro noresume loglevel=7 console=tty1 console=ttyS0,115200 security=apparmor virtio_net.napi_tx=1 nmi_watchdog=0 csm.disabled=0 csm.pipe.enabled=1 csm.config.enabled=1 ,firmware firmware_class.path=/home/kubernetes/bin/nvidia/firmware module.sig_enforce=0 dm_verity.error_behavior=3 dm_verity.max_bios=-1 dm_verity.dev_wait=1 i915.modeset=1 cros_efi cos.disable_systemd_route_mgmt modules-load=vfio-pci root=/dev/dm-0 "dm-mod.create=vroot,,,ro,0 4077568 verity 0 PARTUUID=1CFF1596-0A57-9A43-A7C7-9C3E9ACFBA0F PARTUUID=1CFF1596-0A57-9A43-A7C7-9C3E9ACFBA0F 4096 4096 509696 509696 sha256 76e7ffc53ac6c75c8a10b1bf13ac4abee89314c401a9e9d99f8d514d452d0a6d 107fd67eb7fac9045e19b861d3be2299e57956e453a9888f2e153c2dad8729e6" intel_iommu=on,sm_on
+[    0.051454] DMAR: IOMMU enabled
+[    0.051455] DMAR: Enable scalable mode if hardware supports
+[    0.051457] Unknown kernel command line parameters "noresume ,firmware cros_efi BOOT_IMAGE=/syslinux/vmlinuz.A modules-load=vfio-pci", will be passed to user space.
+[    0.051476] random: crng init done
+[    0.051476] printk: log_buf_len individual max cpu contribution: 4096 bytes
+[    0.051477] printk: log_buf_len total cpu_extra contributions: 225280 bytes
+[    0.051477] printk: log_buf_len min size: 262144 bytes
+[    0.051706] printk: log_buf_len: 524288 bytes
+[    0.051707] printk: early log buf free: 249936(95%)
+[    0.051929] mem auto-init: stack:all(zero), heap alloc:off, heap free:off
+[    0.051933] software IO TLB: area num 64.
+[    0.169109] Memory: 3277824K/469758312K available (16395K kernel code, 2565K rwdata, 8760K rodata, 2112K init, 4356K bss, 7524460K reserved, 0K cma-reserved)
+[    0.169281] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=56, Nodes=2
+[    0.169299] ftrace: allocating 42881 entries in 168 pages
+[    0.169441] ftrace: allocated 168 pages with 3 groups
+[    0.170391] Dynamic Preempt: none
+[    0.170475] rcu: Preemptible hierarchical RCU implementation.
+[    0.170476] rcu: 	RCU restricting CPUs from NR_CPUS=512 to nr_cpu_ids=56.
+[    0.170477] 	Trampoline variant of Tasks RCU enabled.
+[    0.170478] 	Rude variant of Tasks RCU enabled.
+[    0.170478] 	Tracing variant of Tasks RCU enabled.
+[    0.170479] rcu: RCU calculated value of scheduler-enlistment delay is 100 jiffies.
+[    0.170479] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=56
+[    0.173000] NR_IRQS: 33024, nr_irqs: 872, preallocated irqs: 16
+[    0.173209] rcu: srcu_init: Setting srcu_struct sizes based on contention.
+[    0.173266] Console: colour dummy device 80x25
+[    0.173513] printk: console [tty1] enabled
+[    0.365395] printk: console [ttyS0] enabled
+[    0.366126] ACPI: Core revision 20220331
+[    0.366918] APIC: Switch to symmetric I/O mode setup
+[    0.368053] x2apic enabled
+[    0.372495] Switched APIC routing to physical x2apic.
+[    0.378325] ..TIMER: vector=0x30 apic1=0 pin1=0 apic2=-1 pin2=-1
+[    0.379786] clocksource: tsc-early: mask: 0xffffffffffffffff max_cycles: 0x2bf6c4ae424, max_idle_ns: 440795250795 ns
+[    0.381417] Calibrating delay loop (skipped) preset value.. 6099.99 BogoMIPS (lpj=3049998)
+[    0.382505] x86/cpu: User Mode Instruction Prevention (UMIP) activated
+[    0.384557] process: using mwait in idle threads
+[    0.385283] Last level iTLB entries: 4KB 512, 2MB 512, 4MB 256
+[    0.385419] Last level dTLB entries: 4KB 2048, 2MB 2048, 4MB 1024, 1GB 0
+[    0.386420] Spectre V1 : Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+[    0.387424] Spectre V2 : Mitigation: Retpolines
+[    0.388137] Spectre V2 : Spectre v2 / SpectreRSB mitigation: Filling RSB on context switch
+[    0.388419] Spectre V2 : Spectre v2 / SpectreRSB : Filling RSB on VMEXIT
+[    0.389419] Spectre V2 : Enabling Restricted Speculation for firmware calls
+[    0.390422] Spectre V2 : mitigation: Enabling conditional Indirect Branch Prediction Barrier
+[    0.391423] Speculative Store Bypass: Mitigation: Speculative Store Bypass disabled via prctl
+[    0.392420] Speculative Return Stack Overflow: Mitigation: safe RET
+[    0.393429] x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
+[    0.394419] x86/fpu: Supporting XSAVE feature 0x002: 'SSE registers'
+[    0.395419] x86/fpu: Supporting XSAVE feature 0x004: 'AVX registers'
+[    0.396419] x86/fpu: xstate_offset[2]:  576, xstate_sizes[2]:  256
+[    0.397419] x86/fpu: Enabled xstate features 0x7, context size is 832 bytes, using 'compacted' format.
+[    0.412680] Freeing SMP alternatives memory: 48K
+[    0.413421] pid_max: default: 57344 minimum: 448
+[    0.426903] LSM: Security Framework initializing
+[    0.427435] Yama: becoming mindful.
+[    0.428002] LoadPin: ready to pin (currently enforcing)
+[    0.428440] AppArmor: AppArmor initialized
+[    0.429422] LSM support for eBPF active
+[    0.438502] Dentry cache hash table entries: 16777216 (order: 15, 134217728 bytes, vmalloc hugepage)
+[    0.443969] Inode-cache hash table entries: 8388608 (order: 14, 67108864 bytes, vmalloc hugepage)
+[    0.444630] Mount-cache hash table entries: 262144 (order: 9, 2097152 bytes, vmalloc)
+[    0.445595] Mountpoint-cache hash table entries: 262144 (order: 9, 2097152 bytes, vmalloc)
+[    0.651861] smpboot: CPU0: AMD EPYC 7B13 (family: 0x19, model: 0x1, stepping: 0x0)
+[    0.652610] cblist_init_generic: Setting adjustable number of callback queues.
+[    0.653422] cblist_init_generic: Setting shift to 6 and lim to 1.
+[    0.654446] cblist_init_generic: Setting adjustable number of callback queues.
+[    0.655422] cblist_init_generic: Setting shift to 6 and lim to 1.
+[    0.656446] cblist_init_generic: Setting adjustable number of callback queues.
+[    0.657421] cblist_init_generic: Setting shift to 6 and lim to 1.
+[    0.658418] Performance Events: PMU not available due to virtualization, using software events only.
+[    0.660441] signal: max sigframe size: 1776
+[    0.661451] rcu: Hierarchical SRCU implementation.
+[    0.662421] rcu: 	Max phase no-delay instances is 400.
+[    0.663614] NMI watchdog: Perf NMI watchdog permanently disabled
+[    0.665461] smp: Bringing up secondary CPUs ...
+[    0.666338] x86: Booting SMP configuration:
+[    0.666423] .... node  #0, CPUs:        #1  #2  #3  #4  #5  #6  #7  #8  #9 #10 #11 #12 #13 #14 #15 #16 #17 #18 #19 #20 #21 #22 #23 #24 #25 #26 #27
+[    0.684426] .... node  #1, CPUs:   #28 #29 #30 #31 #32 #33 #34 #35 #36 #37 #38 #39 #40 #41 #42 #43 #44 #45 #46 #47 #48 #49 #50 #51 #52 #53 #54 #55
+[    0.704642] smp: Brought up 2 nodes, 56 CPUs
+[    0.706422] smpboot: Max logical packages: 2
+[    0.707088] smpboot: Total of 56 processors activated (341599.77 BogoMIPS)
+[    0.788435] node 1 deferred pages initialised in 78ms
+[    0.788575] node 0 deferred pages initialised in 78ms
+[    0.807480] devtmpfs: initialized
+[    0.808520] x86/mm: Memory block size: 1024MB
+[    0.815440] ACPI: PM: Registering ACPI NVS region [mem 0xbf97f000-0xbf9fefff] (524288 bytes)
+[    0.817521] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 1911260446275000 ns
+[    0.818459] futex hash table entries: 16384 (order: 8, 1048576 bytes, vmalloc)
+[    0.819660] PM: RTC time: 15:31:45, date: 2024-11-09
+[    0.821824] NET: Registered PF_NETLINK/PF_ROUTE protocol family
+[    0.823557] DMA: preallocated 4096 KiB GFP_KERNEL pool for atomic allocations
+[    0.824428] DMA: preallocated 4096 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
+[    0.825428] DMA: preallocated 4096 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
+[    0.827432] audit: initializing netlink subsys (disabled)
+[    0.827436] audit: type=2000 audit(1731166304.849:1): state=initialized audit_enabled=0 res=1
+[    0.827509] thermal_sys: Registered thermal governor 'step_wise'
+[    0.829424] thermal_sys: Registered thermal governor 'user_space'
+[    0.830462] cpuidle: using governor ladder
+[    0.832438] cpuidle: using governor menu
+[    0.834517] acpiphp: ACPI Hot Plug PCI Controller Driver version: 0.5
+[    0.835511] PCI: Using configuration type 1 for base access
+[    0.836422] PCI: Using configuration type 1 for extended access
+[    0.840877] kprobes: kprobe jump-optimization is enabled. All kprobes are optimized if possible.
+[    0.842454] HugeTLB: registered 1.00 GiB page size, pre-allocated 0 pages
+[    0.843422] HugeTLB: 16380 KiB vmemmap can be freed for a 1.00 GiB page
+[    0.844422] HugeTLB: registered 2.00 MiB page size, pre-allocated 0 pages
+[    0.846421] HugeTLB: 28 KiB vmemmap can be freed for a 2.00 MiB page
+[    0.847550] ACPI: Added _OSI(Module Device)
+[    0.848424] ACPI: Added _OSI(Processor Device)
+[    0.849421] ACPI: Added _OSI(3.0 _SCP Extensions)
+[    0.849421] ACPI: Added _OSI(Processor Aggregator Device)
+[    0.853405] ACPI: 3 ACPI AML tables successfully acquired and loaded
+[    0.860923] ACPI: Interpreter enabled
+[    0.861435] ACPI: PM: (supports S0 S3 S5)
+[    0.862071] ACPI: Using IOAPIC for interrupt routing
+[    0.863434] PCI: Using host bridge windows from ACPI; if necessary, use "pci=nocrs" and report a bug
+[    0.864422] PCI: Ignoring E820 reservations for host bridge windows
+[    0.865700] ACPI: Enabled 16 GPEs in block 00 to 0F
+[    0.874680] ACPI: PCI Root Bridge [PCI0] (domain 0000 [bus 00-ff])
+[    0.875425] acpi PNP0A03:00: _OSC: OS supports [ExtendedConfig ASPM ClockPM Segments MSI HPX-Type3]
+[    0.877745] PCI host bridge to bus 0000:00
+[    0.878421] pci_bus 0000:00: Unknown NUMA node; performance will be reduced
+[    0.879421] pci_bus 0000:00: root bus resource [io  0x0000-0x0cf7 window]
+[    0.880422] pci_bus 0000:00: root bus resource [io  0x0d00-0xffff window]
+[    0.881421] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
+[    0.882421] pci_bus 0000:00: root bus resource [mem 0xc0000000-0xfebfefff window]
+[    0.884422] pci_bus 0000:00: root bus resource [bus 00-ff]
+[    0.885528] pci 0000:00:00.0: [8086:1237] type 00 class 0x060000
+[    0.888601] pci 0000:00:01.0: [8086:7110] type 00 class 0x060100
+[    0.907589] pci 0000:00:01.3: [8086:7113] type 00 class 0x068000
+[    0.926442] pci 0000:00:01.3: quirk: [io  0xb000-0xb03f] claimed by PIIX4 ACPI
+[    0.927633] pci 0000:00:03.0: [1af4:1004] type 00 class 0x000000
+[    0.935419] pci 0000:00:03.0: reg 0x10: [io  0xc000-0xc03f]
+[    0.940418] pci 0000:00:03.0: reg 0x14: [mem 0xc0103000-0xc010307f]
+[    0.953667] pci 0000:00:04.0: [1ae0:0042] type 00 class 0x020000
+[    0.962418] pci 0000:00:04.0: reg 0x10: [mem 0xc0102000-0xc0102fff]
+[    0.967419] pci 0000:00:04.0: reg 0x14: [mem 0xc0100000-0xc01003ff]
+[    0.972418] pci 0000:00:04.0: reg 0x18: [mem 0xc0000000-0xc00fffff]
+[    0.982533] pci 0000:00:05.0: [1af4:1005] type 00 class 0x00ff00
+[    0.990418] pci 0000:00:05.0: reg 0x10: [io  0xc040-0xc05f]
+[    0.995418] pci 0000:00:05.0: reg 0x14: [mem 0xc0101000-0xc010103f]
+[    1.010496] ACPI: PCI: Interrupt link LNKA configured for IRQ 10
+[    1.012487] ACPI: PCI: Interrupt link LNKB configured for IRQ 10
+[    1.015484] ACPI: PCI: Interrupt link LNKC configured for IRQ 11
+[    1.017485] ACPI: PCI: Interrupt link LNKD configured for IRQ 11
+[    1.019440] ACPI: PCI: Interrupt link LNKS configured for IRQ 9
+[    1.029457] iommu: Default domain type: Translated 
+[    1.030200] iommu: DMA domain TLB invalidation policy: lazy mode 
+[    1.031538] SCSI subsystem initialized
+[    1.032433] libata version 3.00 loaded.
+[    1.032467] pps_core: LinuxPPS API ver. 1 registered
+[    1.032467] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
+[    1.034427] PTP clock support registered
+[    1.035644] Registered efivars operations
+[    1.036245] PCI: Using ACPI for IRQ routing
+[    1.036421] PCI: pci_cache_line_size set to 64 bytes
+[    1.036479] e820: reserve RAM buffer [mem 0x00055000-0x0005ffff]
+[    1.036481] e820: reserve RAM buffer [mem 0x00098000-0x0009ffff]
+[    1.036482] e820: reserve RAM buffer [mem 0xbf6ed000-0xbfffffff]
+[    1.036484] e820: reserve RAM buffer [mem 0xbffe0000-0xbfffffff]
+[    1.037487] clocksource: Switched to clocksource kvm-clock
+[    1.038524] VFS: Disk quotas dquot_6.6.0
+[    1.039195] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
+[    1.040513] AppArmor: AppArmor Filesystem Enabled
+[    1.041291] pnp: PnP ACPI init
+[    1.042375] pnp: PnP ACPI: found 7 devices
+[    1.045344] NET: Registered PF_INET protocol family
+[    1.046372] IP idents hash table entries: 262144 (order: 9, 2097152 bytes, vmalloc)
+[    1.049925] tcp_listen_portaddr_hash hash table entries: 65536 (order: 8, 1048576 bytes, vmalloc)
+[    1.051441] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, vmalloc)
+[    1.052712] TCP established hash table entries: 524288 (order: 10, 4194304 bytes, vmalloc hugepage)
+[    1.054495] TCP bind hash table entries: 65536 (order: 9, 2097152 bytes, vmalloc)
+[    1.055822] TCP: Hash tables configured (established 524288 bind 65536)
+[    1.057065] UDP hash table entries: 65536 (order: 9, 2097152 bytes, vmalloc)
+[    1.058465] UDP-Lite hash table entries: 65536 (order: 9, 2097152 bytes, vmalloc)
+[    1.059957] NET: Registered PF_UNIX/PF_LOCAL protocol family
+[    1.060913] NET: Registered PF_XDP protocol family
+[    1.061685] pci_bus 0000:00: resource 4 [io  0x0000-0x0cf7 window]
+[    1.062694] pci_bus 0000:00: resource 5 [io  0x0d00-0xffff window]
+[    1.063711] pci_bus 0000:00: resource 6 [mem 0x000a0000-0x000bffff window]
+[    1.064839] pci_bus 0000:00: resource 7 [mem 0xc0000000-0xfebfefff window]
+[    1.066047] pci 0000:00:00.0: Limiting direct PCI/PCI transfers
+[    1.067031] PCI: CLS 0 bytes, default 64
+[    1.067703] PCI-DMA: Using software bounce buffering for IO (SWIOTLB)
+[    1.068841] software IO TLB: mapped [mem 0x00000000b7eff000-0x00000000bbeff000] (64MB)
+[    1.071726] clocksource: tsc: mask: 0xffffffffffffffff max_cycles: 0x2bf6c4ae424, max_idle_ns: 440795250795 ns
+[    1.073580] clocksource: Switched to clocksource tsc
+[    1.082576] Initialise system trusted keyrings
+[    1.083412] Key type blacklist registered
+[    1.084201] workingset: timestamp_bits=40 max_order=27 bucket_order=0
+[    1.088105] SGI XFS with ACLs, security attributes, quota, no debug enabled
+[    1.089882] 9p: Installing v9fs 9p2000 file system support
+[    1.090913] integrity: Platform Keyring initialized
+[    1.091835] NET: Registered PF_ALG protocol family
+[    1.092672] xor: automatically using best checksumming function   avx       
+[    1.093874] Key type asymmetric registered
+[    1.094568] Asymmetric key parser 'x509' registered
+[    1.095397] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 248)
+[    1.096691] io scheduler mq-deadline registered
+[    1.098814] input: Power Button as /devices/LNXSYSTM:00/LNXPWRBN:00/input/input0
+[    1.100261] ACPI: button: Power Button [PWRF]
+[    1.101053] input: Sleep Button as /devices/LNXSYSTM:00/LNXSLPBN:00/input/input1
+[    1.102598] ACPI: button: Sleep Button [SLPF]
+[    1.109105] ACPI: \_SB_.LNKC: Enabled at IRQ 11
+[    1.109963] virtio-pci 0000:00:03.0: virtio_pci: leaving for legacy driver
+[    1.115288] ACPI: \_SB_.LNKA: Enabled at IRQ 10
+[    1.116177] virtio-pci 0000:00:05.0: virtio_pci: leaving for legacy driver
+[    1.119954] Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
+[    1.121142] 00:03: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
+[    1.122525] 00:04: ttyS1 at I/O 0x2f8 (irq = 3, base_baud = 115200) is a 16550A
+[    1.123938] 00:05: ttyS2 at I/O 0x3e8 (irq = 6, base_baud = 115200) is a 16550A
+[    1.125301] 00:06: ttyS3 at I/O 0x2e8 (irq = 7, base_baud = 115200) is a 16550A
+[    1.126737] Non-volatile memory driver v1.3
+[    1.146275] tpm_tis MSFT0101:00: 2.0 TPM (device-id 0x9009, rev-id 0)
+[    1.160942] loop: module loaded
+[    1.161559] Guest personality initialized and is inactive
+[    1.162572] VMCI host device registered (name=vmci, major=10, minor=126)
+[    1.163724] Initialized host personality
+[    1.173724] scsi host0: Virtio SCSI HBA
+[    1.177125] scsi 0:0:1:0: Direct-Access     Google   PersistentDisk   1    PQ: 0 ANSI: 6
+[    1.198042] VMware PVSCSI driver - version 1.0.7.0-k
+[    1.199040] hv_vmbus: registering driver hv_storvsc
+[    1.200109] sd 0:0:1:0: [sda] 209715200 512-byte logical blocks: (107 GB/100 GiB)
+[    1.200424] ixgbevf: Intel(R) 10 Gigabit PCI Express Virtual Function Network Driver
+[    1.201406] sd 0:0:1:0: [sda] 4096-byte physical blocks
+[    1.202643] ixgbevf: Copyright (c) 2009 - 2018 Intel Corporation.
+[    1.202720] VMware vmxnet3 virtual NIC driver - version 1.7.0.0-k-NAPI
+[    1.203547] sd 0:0:1:0: [sda] Write Protect is off
+[    1.204516] hv_vmbus: registering driver hv_netvsc
+[    1.205569] sd 0:0:1:0: [sda] Mode Sense: 1f 00 00 08
+[    1.205635] sd 0:0:1:0: [sda] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
+[    1.206460] i8042: PNP: PS/2 Controller [PNP0303:KBD,PNP0f13:MOU] at 0x60,0x64 irq 1,12
+[    1.210223] i8042: Warning: Keylock active
+[    1.212990] GPT:Primary header thinks Alt. header is not at the end of the disk.
+[    1.213070] serio: i8042 KBD port at 0x60,0x64 irq 1
+[    1.214223] GPT:20971519 != 209715199
+[    1.214225] GPT:Alternate GPT header not at the end of the disk.
+[    1.214226] GPT:20971519 != 209715199
+[    1.214227] GPT: Use GNU Parted to correct GPT errors.
+[    1.214234]  sda: sda1 sda2 sda3 sda4 sda5 sda6 sda7 sda8 sda9 sda10 sda11 sda12
+[    1.214898] sd 0:0:1:0: [sda] Attached SCSI disk
+[    1.215114] serio: i8042 AUX port at 0x60,0x64 irq 12
+[    1.221525] hv_vmbus: registering driver hyperv_keyboard
+[    1.222566] rtc_cmos 00:00: RTC can wake from S4
+[    1.224418] rtc_cmos 00:00: registered as rtc0
+[    1.225214] rtc_cmos 00:00: alarms up to one day, 114 bytes nvram
+[    1.226251] iTCO_vendor_support: vendor-support=0
+[    1.227019] device-mapper: core: CONFIG_IMA_DISABLE_HTABLE is disabled. Duplicate IMA measurements will not be recorded in the IMA log.
+[    1.229127] device-mapper: ioctl: 4.47.0-ioctl (2022-07-28) initialised: dm-devel@redhat.com
+[    1.230639] pstore: Registered efi as persistent store backend
+[    1.231734] hv_utils: Registering HyperV Utility Driver
+[    1.232617] hv_vmbus: registering driver hv_utils
+[    1.233427] hv_vmbus: registering driver hv_balloon
+[    1.234308] Mirror/redirect action on
+[    1.245113] Initializing XFRM netlink socket
+[    1.246057] NET: Registered PF_INET6 protocol family
+[    1.247444] Segment Routing with IPv6
+[    1.248114] In-situ OAM (IOAM) with IPv6
+[    1.249017] NET: Registered PF_PACKET protocol family
+[    1.249866] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
+[    1.252065] 9pnet: Installing 9P2000 support
+[    1.252887] NET: Registered PF_VSOCK protocol family
+[    1.260243] IPI shorthand broadcast: enabled
+[    1.261228] sched_clock: Marking stable (1058006846, 203202048)->(1305235347, -44026453)
+[    1.262797] registered taskstats version 1
+[    1.263752] Loading compiled-in X.509 certificates
+[    1.265349] Loaded X.509 cert 'Google LLC: Container-Optimized OS kernel signing key: 9ecb648d9af2a9bc414c18e08e28104367f506a3'
+[    1.267401] Loaded X.509 cert 'Google: Container-Optimized OS: 2efea493fc148b35859d0bc8c3dd71a139fc7ab411283e06f6c10b5a6b17e355'
+[    1.269424] pstore: Using crash dump compression: deflate
+[    1.270663] AppArmor: AppArmor sha1 policy hashing enabled
+[    1.271980] integrity: Loading X.509 certificate: UEFI:db
+[    1.273162] integrity: Loaded X.509 cert 'Google LLC.: UEFI DB Key v10: 4b4eb27158d8dd4a5bb760f5677f184708c15fdaf94d830a7e59c94b065a2724'
+[    1.275322] ima: Allocated hash algorithm: sha256
+[    1.276687] ima: Can not allocate sha384 (reason: -2)
+[    1.307286] ima: No architecture policies found
+[    1.309411] PM:   Magic number: 0:775:537
+[    1.310413] device-mapper: init: waiting for all devices to be available before creating mapped devices
+[    1.432565] input: AT Translated Set 2 keyboard as /devices/platform/i8042/serio0/input/input2
+[    1.434421] device-mapper: verity: sha256 using implementation "sha256-generic"
+[    1.436220] device-mapper: ioctl: dm-0 (vroot) is ready
+[    1.437099] clk: Disabling unused clocks
+[    1.438556] md: Waiting for all devices to be available before autodetect
+[    1.439668] md: If you don't use raid, use raid=noautodetect
+[    1.440587] md: Autodetecting RAID arrays.
+[    1.441252] md: autorun ...
+[    1.441714] md: ... autorun DONE.
+[    1.452711] EXT4-fs (dm-0): mounting ext2 file system using the ext4 subsystem
+[    1.454908] EXT4-fs (dm-0): mounted filesystem without journal. Quota mode: none.
+[    1.456186] VFS: Mounted root (ext2 filesystem) readonly on device 253:0.
+[    1.460295] devtmpfs: mounted
+[    1.468167] LoadPin: dm-0 (253:0): read-only
+[    1.468888] LoadPin: load pinning engaged.
+[    1.469561] LoadPin: x509-certificate pinned obj="/etc/ima/pubkey.x509" pid=1 cmdline=""
+[    1.471598] integrity: Loading X.509 certificate: /etc/ima/pubkey.x509
+[    1.473060] integrity: Loaded X.509 cert 'Google LLC: Container-Optimized OS kernel signing key: 9ecb648d9af2a9bc414c18e08e28104367f506a3'
+[    1.476360] Freeing unused decrypted memory: 2036K
+[    1.477828] Freeing unused kernel image (initmem) memory: 2112K
+[    1.478781] Write protecting the kernel read-only data: 28672k
+[    1.480646] Freeing unused kernel image (text/rodata gap) memory: 2036K
+[    1.482123] Freeing unused kernel image (rodata/data gap) memory: 1480K
+[    1.483306] Run /usr/lib/systemd/systemd as init process
+[    1.484160]   with arguments:
+[    1.484161]     /usr/lib/systemd/systemd
+[    1.484162]     noresume
+[    1.484163]     ,firmware
+[    1.484164]     cros_efi
+[    1.484165]   with environment:
+[    1.484166]     HOME=/
+[    1.484167]     TERM=linux
+[    1.484168]     BOOT_IMAGE=/syslinux/vmlinuz.A
+[    1.484169]     modules-load=vfio-pci
+[    1.713510] systemd[1]: systemd 254 running in system mode (+PAM +AUDIT -SELINUX +APPARMOR +IMA +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL -ACL +BLKID -CURL -ELFUTILS -FIDO2 +IDN2 -IDN -IPTC +KMOD -LIBCRYPTSETUP +LIBFDISK -PCRE2 -PWQUALITY -P11KIT -QRENCODE -TPM2 -BZIP2 +LZ4 -XZ -ZLIB -ZSTD -BPF_FRAMEWORK -XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified)
+[    1.718484] systemd[1]: Detected virtualization kvm.
+[    1.719419] systemd[1]: Detected architecture x86-64.
+[    1.728019] systemd[1]: Initializing machine ID from VM UUID.
+[    1.729036] systemd[1]: Installed transient /etc/machine-id file.
+[    2.015817] systemd[1]: Configuration file /usr/lib/systemd/system/systemd-tmpfiles-clean.timer is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
+[    2.020225] systemd[1]: Configuration file /usr/lib/systemd/system/crash-sender.timer is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
+[    2.075124] systemd[1]: Queued start job for default target multi-user.target.
+[    2.086993] systemd[1]: Created slice system-getty.slice.
+[    2.091809] systemd[1]: Created slice system-modprobe.slice.
+[    2.096843] systemd[1]: Created slice system-serial\x2dgetty.slice.
+[    2.101805] systemd[1]: Created slice system-sysdaemons.slice.
+[    2.106820] systemd[1]: Created slice system-systemd\x2dfsck.slice.
+[    2.111746] systemd[1]: Created slice user.slice.
+[    2.116318] systemd[1]: Started systemd-ask-password-console.path.
+[    2.121290] systemd[1]: Started systemd-ask-password-wall.path.
+[    2.126405] systemd[1]: Set up automount proc-sys-fs-binfmt_misc.automount.
+[    2.131248] systemd[1]: Expecting device dev-sda8.device...
+[    2.135237] systemd[1]: Expecting device dev-stateful.device...
+[    2.139235] systemd[1]: Expecting device dev-ttyS0.device...
+[    2.143261] systemd[1]: Reached target paths.target.
+[    2.147248] systemd[1]: Reached target remote-fs.target.
+[    2.152240] systemd[1]: Reached target slices.target.
+[    2.157247] systemd[1]: Reached target swap.target.
+[    2.162638] systemd[1]: Listening on systemd-coredump.socket.
+[    2.167296] systemd[1]: Listening on systemd-initctl.socket.
+[    2.172482] systemd[1]: Listening on systemd-journald-audit.socket.
+[    2.177364] systemd[1]: Listening on systemd-journald-dev-log.socket.
+[    2.182381] systemd[1]: Listening on systemd-journald.socket.
+[    2.187369] systemd[1]: Listening on systemd-networkd.socket.
+[    2.192386] systemd[1]: Listening on systemd-udevd-control.socket.
+[    2.197339] systemd[1]: Listening on systemd-udevd-kernel.socket.
+[    2.212295] systemd[1]: Mounting dev-hugepages.mount...
+[    2.218415] systemd[1]: Mounting dev-mqueue.mount...
+[    2.228053] systemd[1]: Mounting mnt-disks.mount...
+[    2.234323] systemd[1]: Mounting sys-firmware-efi-efivars.mount...
+[    2.240413] systemd[1]: Mounting sys-kernel-debug.mount...
+[    2.246401] systemd[1]: Mounting sys-kernel-tracing.mount...
+[    2.251823] systemd[1]: Mounting tmp.mount...
+[    2.257442] systemd[1]: Starting dev-shm-remount.service...
+[    2.262499] systemd[1]: Starting kmod-static-nodes.service...
+[    2.268259] systemd[1]: Starting modprobe@configfs.service...
+[    2.273281] systemd[1]: Starting modprobe@dm_mod.service...
+[    2.279262] systemd[1]: Starting modprobe@drm.service...
+[    2.284197] systemd[1]: Starting modprobe@efi_pstore.service...
+[    2.289244] systemd[1]: Starting modprobe@fuse.service...
+[    2.295283] systemd[1]: Starting modprobe@loop.service...
+[    2.300361] systemd[1]: Starting setup-install-attributes.service...
+[    2.305032] fuse: init (API version 7.37)
+[    2.307599] systemd[1]: Starting systemd-journald.service...
+[    2.314471] systemd[1]: Starting systemd-modules-load.service...
+[    2.320313] systemd-journald[636]: Collecting audit messages is enabled.
+[    2.320450] systemd[1]: Starting systemd-remount-fs.service...
+[    2.327596] systemd[1]: Starting systemd-udev-trigger.service...
+[    2.329319] VFIO - User Level meta-driver version: 0.3
+[    2.334589] systemd[1]: Starting warm-up.service...
+[    2.341405] systemd[1]: Started systemd-journald.service.
+[    2.609152] cryptd: max_cpu_qlen set to 1000
+[    2.612961] ACPI: \_SB_.LNKD: Enabled at IRQ 11
+[    2.615269] gvnic 0000:00:04.0: Driver is running with GQI QPL queue format.
+[    2.616455] gvnic 0000:00:04.0: MAC addr: 42:01:0a:80:00:05
+[    2.617440] gvnic 0000:00:04.0: JUMBO FRAMES device option enabled.
+[    2.618568] gvnic 0000:00:04.0: TX queues 16, RX queues 16
+[    2.619470] gvnic 0000:00:04.0: Max TX queues 16, Max RX queues 16
+[    2.632948] AVX2 version of gcm_enc/dec engaged.
+[    2.633492] gvnic 0000:00:04.0: GVE version 1.0.0
+[    2.634616] gvnic 0000:00:04.0: GVE queue format 2
+[    2.635687] AES CTR mode by8 optimization enabled
+[    2.703380] gvnic 0000:00:04.0 eth0: Device link is up.
+[    2.704443] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[    2.712396] EXT4-fs (sda8): mounted filesystem with ordered data mode. Quota mode: none.
+[    2.866589] EXT4-fs (sda1): mounted filesystem with ordered data mode. Quota mode: none.
+[    2.935516] systemd-journald[636]: Received client request to flush runtime journal.
+[    2.971373] EXT4-fs (sda1): resizing filesystem from 1533435 to 25126395 blocks
+[    3.294739] EXT4-fs (sda1): resized filesystem to 25126395
+[    3.421739] EXT4-fs (sda1): re-mounted. Quota mode: none.
+[    3.430964] EXT4-fs (sda1): re-mounted. Quota mode: none.
+[    3.438493] EXT4-fs (sda1): re-mounted. Quota mode: none.
+[    3.439560] EXT4-fs (sda1): re-mounted. Quota mode: none.
+[    5.024487] Bridge firewalling registered
+[    8.629918] EXT4-fs (sda1): re-mounted. Quota mode: none.
+[    9.390502] EXT4-fs (sda1): re-mounted. Quota mode: none.
+[   11.349036] EXT4-fs (sda1): re-mounted. Quota mode: none.
+[   12.272504] io scheduler bfq registered
+[   15.843182] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[   15.850989] IPv6: ADDRCONF(NETDEV_CHANGE): veth59e079d9: link becomes ready
+[   15.859626] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[   15.867152] IPv6: ADDRCONF(NETDEV_CHANGE): veth17548aa0: link becomes ready
+[   15.875762] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[   15.884010] IPv6: ADDRCONF(NETDEV_CHANGE): veth37a5f1d4: link becomes ready
+[   17.358006] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[   17.365759] IPv6: ADDRCONF(NETDEV_CHANGE): veth5e08f5de: link becomes ready
+[   22.629105] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[   22.636866] IPv6: ADDRCONF(NETDEV_CHANGE): vetha0a787d6: link becomes ready
+[   22.653222] IPv6: ADDRCONF(NETDEV_CHANGE): veth0c5627c5: link becomes ready
+[   22.661251] IPv6: ADDRCONF(NETDEV_CHANGE): vethb13fc6da: link becomes ready
+[   23.598345] IPv6: ADDRCONF(NETDEV_CHANGE): veth803c0894: link becomes ready
+[   24.605974] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[   24.613590] IPv6: ADDRCONF(NETDEV_CHANGE): veth09e9b876: link becomes ready
+[   25.601375] IPv6: ADDRCONF(NETDEV_CHANGE): veth0dd9fa4f: link becomes ready
+[   27.676922] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[   27.683397] IPv6: ADDRCONF(NETDEV_CHANGE): veth4763d351: link becomes ready
+[   28.943894] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+[   28.951682] IPv6: ADDRCONF(NETDEV_CHANGE): veth3681f259: link becomes ready
+[   29.165296] IPv6: ADDRCONF(NETDEV_CHANGE): veth721fbd7a: link becomes ready


### PR DESCRIPTION
I wanted to quickly compare the scaling governor settings between aws and google. I did not see any cpufreq directory under /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor or a policy directory but found other references to default_governor and found that both were set to performance. Another notable thing is that google
is using their containerOS while aws has something based on centos (amazon linux I think because yum
is there)