### PR TITLE
osu: fix runs for gpu 128 GKE and CE

### DIFF
--- a/experiments/google/README.md
+++ b/experiments/google/README.md
@@ -1,6 +1,10 @@
 # Google Cloud Experiments
 
-This directory will hold experiments for Google Cloud.
+This directory will hold experiments for Google Cloud. 
 
 - [gke/cpu](gke/cpu): CPU experiments for Google Kubernetes Engine
 - [gke/gpu](gpu/gpu): GPU experiments for Google Kubernetes Engine
+
+## OSU Benchmarks
+
+Note that for our first experiments, we ran OSU across sizes, however we made the mistake of using flux submit for the GPU runs, which isn't blocking, and meant that osu latency would interfere with bandwidth. To fix this we re-ran GPU for sizes 16 nodes for each of Compute Engine and GKE. This size is what should be used for data analysis.

--- a/experiments/google/compute-engine/gpu/size16/README.md
+++ b/experiments/google/compute-engine/gpu/size16/README.md
@@ -237,6 +237,7 @@ oras push ghcr.io/converged-computing/metrics-operator-experiments/performance:c
 #### OSU
 
 Write this script to the filesystem `flux-run-combinations.sh`
+Note that the initial study in August 2024 used flux submit, which isn't blocking (and erroneous since they run at the same time). We redid this size in March 2025 with flux run, ensuring it would be blocking.
 
 ```bash
 #/bin/bash
@@ -258,13 +259,13 @@ for i in $hosts; do
   dequeue_from_list $list
   for j in $list; do
     echo "${i} ${j}"
-    flux submit -N 2 -n 2 \
+    flux run -N 2 -n 2 \
       --setattr=user.study_id=$app-2-iter-$iter \
       --requires="hosts:${i},${j}" \
       -o cpu-affinity=per-task \
       -g 1 -o gpu-affinity=per-task \
       singularity exec --nv /opt/containers/metric-osu-gpu_google-gpu.sif /opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency -d cuda H H
-    flux submit -N 2 -n 2 \
+    flux run -N 2 -n 2 \
       --setattr=user.study_id=$app-2-iter-$iter \
       --requires="hosts:${i},${j}" \
       -o cpu-affinity=per-task \
@@ -298,7 +299,12 @@ done
 
 # When they are done:
 ./save.sh $output
+
+# August 2024
 oras push ghcr.io/converged-computing/metrics-operator-experiments/performance:compute-engine-gpu-16-$app $output
+
+# March 2025 with fixed osu latency and osu bw
+oras push ghcr.io/converged-computing/metrics-operator-experiments/performance:compute-engine-gpu-16-$app-fixed $output
 ```
 
 #### Quicksilver

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-0-1051964997632.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-0-1051964997632.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      24.71
+1                      24.37
+2                      24.61
+4                      24.51
+8                      24.43
+16                     24.39
+32                     24.23
+64                     24.40
+128                    24.19
+256                    24.53
+512                    24.81
+1024                   25.39
+2048                   29.46
+4096                   31.57
+8192                   36.56
+16384                  43.71
+32768                  66.71
+65536                 174.45
+131072                186.18
+262144                235.77
+524288                349.58
+1048576               564.08
+2097152               970.02
+4194304              1868.56
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-006"]}}, "user": {"study_id": "osu-2-iter-0"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925379.8451526,"name":"init"}
+{"timestamp":1742925379.8460701,"name":"starting"}
+{"timestamp":1742925379.8658693,"name":"shell.init","context":{"service":"501043911-shell-fUdjYatP","leader-rank":5,"size":2}}
+{"timestamp":1742925379.9225433,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925405.0883598,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2472,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925405.1001337,"name":"complete","context":{"status":0}}
+{"timestamp":1742925405.1001668,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-0-1480337653760.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-0-1480337653760.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.18
+2                       0.39
+4                       0.68
+8                       1.48
+16                      3.26
+32                      6.08
+64                     20.84
+128                    40.89
+256                    78.46
+512                   152.48
+1024                  295.84
+2048                  539.71
+4096                  878.73
+8192                 1315.63
+16384                1656.37
+32768                1967.43
+65536                2194.64
+131072               2150.22
+262144               2056.25
+524288               1924.40
+1048576              1853.76
+2097152              1761.99
+4194304              1715.88
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-006"]}}, "user": {"study_id": "osu-2-iter-0"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925405.3776855,"name":"init"}
+{"timestamp":1742925405.3786778,"name":"starting"}
+{"timestamp":1742925405.3981018,"name":"shell.init","context":{"service":"501043911-shell-fftPNRGs","leader-rank":5,"size":2}}
+{"timestamp":1742925405.4020319,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925414.4804258,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2525,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925414.4866488,"name":"complete","context":{"status":0}}
+{"timestamp":1742925414.4866798,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-1-1637775048704.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-1-1637775048704.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      24.53
+1                      24.95
+2                      25.18
+4                      25.36
+8                      24.93
+16                     24.43
+32                     24.97
+64                     24.56
+128                    25.23
+256                    26.02
+512                    25.40
+1024                   26.45
+2048                   29.49
+4096                   31.35
+8192                   36.66
+16384                  45.80
+32768                  67.06
+65536                 181.80
+131072                189.26
+262144                238.14
+524288                356.01
+1048576               562.24
+2097152               965.45
+4194304              1708.20
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-002"]}}, "user": {"study_id": "osu-2-iter-1"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925414.761935,"name":"init"}
+{"timestamp":1742925414.7628424,"name":"starting"}
+{"timestamp":1742925414.7843826,"name":"shell.init","context":{"service":"501043911-shell-fk2FaDkj","leader-rank":1,"size":2}}
+{"timestamp":1742925414.8324976,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925439.7674615,"name":"shell.task-exit","context":{"localid":0,"rank":1,"state":"Exited","pid":2329,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925439.7992711,"name":"complete","context":{"status":0}}
+{"timestamp":1742925439.7993052,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-1-2062540603392.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-1-2062540603392.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.20
+2                       0.50
+4                       0.92
+8                       1.49
+16                      3.58
+32                      7.05
+64                     20.39
+128                    38.56
+256                    74.51
+512                   142.02
+1024                  271.58
+2048                  507.87
+4096                  829.86
+8192                 1384.97
+16384                1849.12
+32768                2149.54
+65536                2188.41
+131072               2194.09
+262144               1989.21
+524288               1882.12
+1048576              1843.67
+2097152              1829.40
+4194304              1928.82
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-002"]}}, "user": {"study_id": "osu-2-iter-1"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925440.0800998,"name":"init"}
+{"timestamp":1742925440.0810995,"name":"starting"}
+{"timestamp":1742925440.1029232,"name":"shell.init","context":{"service":"501043911-shell-fwBQeiZ5","leader-rank":1,"size":2}}
+{"timestamp":1742925440.1071765,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925448.7218251,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2244,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925448.7313514,"name":"complete","context":{"status":0}}
+{"timestamp":1742925448.731385,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-10-6579504021504.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-10-6579504021504.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      30.16
+1                      30.22
+2                      30.47
+4                      30.38
+8                      30.69
+16                     30.46
+32                     30.60
+64                     30.74
+128                    30.68
+256                    31.60
+512                    31.79
+1024                   32.73
+2048                   36.24
+4096                   38.27
+8192                   43.85
+16384                  54.69
+32768                  80.31
+65536                 211.02
+131072                210.16
+262144                271.94
+524288                367.93
+1048576               591.96
+2097152               975.44
+4194304              1859.91
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-007"]}}, "user": {"study_id": "osu-2-iter-10"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925709.3119636,"name":"init"}
+{"timestamp":1742925709.3130028,"name":"starting"}
+{"timestamp":1742925709.3332787,"name":"shell.init","context":{"service":"501043911-shell-f3yqHEv7h","leader-rank":5,"size":2}}
+{"timestamp":1742925709.3373182,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925730.459857,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2816,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925730.4663754,"name":"complete","context":{"status":0}}
+{"timestamp":1742925730.4664104,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-10-6939090092032.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-10-6939090092032.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.17
+2                       0.34
+4                       0.79
+8                       1.05
+16                      3.45
+32                      8.12
+64                     21.08
+128                    43.15
+256                    77.26
+512                   151.05
+1024                  288.65
+2048                  524.34
+4096                  858.74
+8192                 1397.65
+16384                1808.67
+32768                2147.22
+65536                2343.34
+131072               2199.78
+262144               2087.49
+524288               2018.49
+1048576              1963.70
+2097152              1974.59
+4194304              1962.15
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-007"]}}, "user": {"study_id": "osu-2-iter-10"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925730.7448459,"name":"init"}
+{"timestamp":1742925730.7459881,"name":"starting"}
+{"timestamp":1742925730.7653837,"name":"shell.init","context":{"service":"501043911-shell-f49H8dX6P","leader-rank":5,"size":2}}
+{"timestamp":1742925730.7693317,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925739.0274324,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2856,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925739.032778,"name":"complete","context":{"status":0}}
+{"timestamp":1742925739.0328097,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-11-7082703060992.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-11-7082703060992.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      33.13
+1                      33.10
+2                      33.37
+4                      33.43
+8                      33.63
+16                     33.59
+32                     33.73
+64                     33.50
+128                    33.98
+256                    34.52
+512                    35.58
+1024                   35.72
+2048                   40.93
+4096                   42.92
+8192                   49.99
+16384                  62.89
+32768                  93.69
+65536                 254.34
+131072                265.08
+262144                338.12
+524288                465.88
+1048576               709.14
+2097152              1147.02
+4194304              1945.75
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-008"]}}, "user": {"study_id": "osu-2-iter-11"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925739.3056464,"name":"init"}
+{"timestamp":1742925739.306792,"name":"starting"}
+{"timestamp":1742925739.3274944,"name":"shell.init","context":{"service":"501043911-shell-f4D3wDXN7","leader-rank":5,"size":2}}
+{"timestamp":1742925739.3313041,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925762.8557854,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2897,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925762.8631096,"name":"complete","context":{"status":0}}
+{"timestamp":1742925762.8631446,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-11-7482537672704.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-11-7482537672704.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.17
+2                       0.29
+4                       0.74
+8                       1.16
+16                      5.00
+32                     10.29
+64                     19.27
+128                    39.73
+256                    77.02
+512                   144.59
+1024                  274.00
+2048                  473.71
+4096                  797.04
+8192                 1209.24
+16384                1499.83
+32768                1709.76
+65536                1793.33
+131072               1683.22
+262144               1684.49
+524288               1655.78
+1048576              1661.35
+2097152              1630.22
+4194304              1578.29
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-008"]}}, "user": {"study_id": "osu-2-iter-11"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925763.1372416,"name":"init"}
+{"timestamp":1742925763.1384499,"name":"starting"}
+{"timestamp":1742925763.1581929,"name":"shell.init","context":{"service":"501043911-shell-f4PZ7ERQ3","leader-rank":5,"size":2}}
+{"timestamp":1742925763.1623526,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925772.8602521,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2937,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925772.8703179,"name":"complete","context":{"status":0}}
+{"timestamp":1742925772.8703496,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-12-7650393718784.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-12-7650393718784.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      24.47
+1                      24.73
+2                      24.41
+4                      24.50
+8                      24.63
+16                     24.58
+32                     24.48
+64                     24.78
+128                    24.57
+256                    25.64
+512                    25.84
+1024                   26.37
+2048                   30.28
+4096                   32.54
+8192                   38.32
+16384                  48.55
+32768                  74.33
+65536                 182.63
+131072                187.55
+262144                237.96
+524288                361.29
+1048576               568.08
+2097152               950.36
+4194304              1721.19
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-014"]}}, "user": {"study_id": "osu-2-iter-12"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925773.1424935,"name":"init"}
+{"timestamp":1742925773.1436775,"name":"starting"}
+{"timestamp":1742925773.1628859,"name":"shell.init","context":{"service":"501043911-shell-f4Txr6Xt3","leader-rank":5,"size":2}}
+{"timestamp":1742925773.1668432,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925791.9279084,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2977,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925791.93644,"name":"complete","context":{"status":0}}
+{"timestamp":1742925791.9364715,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-12-7970335227904.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-12-7970335227904.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.18
+2                       0.37
+4                       0.79
+8                       1.38
+16                      3.83
+32                      7.08
+64                     21.05
+128                    38.06
+256                    75.84
+512                   144.80
+1024                  270.50
+2048                  494.21
+4096                  816.97
+8192                 1347.19
+16384                1627.63
+32768                1892.77
+65536                2094.38
+131072               1977.91
+262144               2025.29
+524288               1909.90
+1048576              1814.19
+2097152              1829.24
+4194304              1750.09
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-014"]}}, "user": {"study_id": "osu-2-iter-12"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925792.2122805,"name":"init"}
+{"timestamp":1742925792.2134438,"name":"starting"}
+{"timestamp":1742925792.2325313,"name":"shell.init","context":{"service":"501043911-shell-f4cNJEPwu","leader-rank":5,"size":2}}
+{"timestamp":1742925792.2362523,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925801.0884383,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":3017,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925801.0950744,"name":"complete","context":{"status":0}}
+{"timestamp":1742925801.0951054,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-13-8123964194816.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-13-8123964194816.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      24.92
+1                      24.48
+2                      24.84
+4                      25.63
+8                      24.85
+16                     24.90
+32                     25.04
+64                     25.28
+128                    25.25
+256                    25.91
+512                    25.83
+1024                   26.05
+2048                   29.39
+4096                   31.57
+8192                   37.01
+16384                  46.66
+32768                  69.10
+65536                 181.54
+131072                192.33
+262144                249.83
+524288                375.48
+1048576               604.71
+2097152              1057.64
+4194304              1919.99
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-002,flux-001"]}}, "user": {"study_id": "osu-2-iter-13"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925801.3692183,"name":"init"}
+{"timestamp":1742925801.3703814,"name":"starting"}
+{"timestamp":1742925801.3908958,"name":"shell.init","context":{"service":"501043911-shell-f4gQMu1TV","leader-rank":0,"size":2}}
+{"timestamp":1742925801.3944645,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925820.8813996,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2543,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925820.8854139,"name":"complete","context":{"status":0}}
+{"timestamp":1742925820.8854432,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-13-8456002076672.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-13-8456002076672.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.17
+2                       0.50
+4                       0.57
+8                       1.26
+16                      4.28
+32                      6.85
+64                     21.16
+128                    40.11
+256                    75.87
+512                   147.14
+1024                  283.60
+2048                  506.90
+4096                  829.02
+8192                 1326.18
+16384                1820.29
+32768                2173.31
+65536                2229.40
+131072               2110.93
+262144               1916.67
+524288               1867.40
+1048576              1800.88
+2097152              1813.52
+4194304              1785.09
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-002,flux-001"]}}, "user": {"study_id": "osu-2-iter-13"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925821.1607454,"name":"init"}
+{"timestamp":1742925821.1619604,"name":"starting"}
+{"timestamp":1742925821.1810286,"name":"shell.init","context":{"service":"501043911-shell-f4q8Ewwhy","leader-rank":0,"size":2}}
+{"timestamp":1742925821.1846857,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925830.0127137,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2587,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925830.0164905,"name":"complete","context":{"status":0}}
+{"timestamp":1742925830.0165207,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-14-8609245167616.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-14-8609245167616.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      24.90
+1                      24.79
+2                      24.69
+4                      24.68
+8                      24.63
+16                     24.51
+32                     25.23
+64                     24.80
+128                    24.48
+256                    25.05
+512                    25.47
+1024                   25.99
+2048                   29.39
+4096                   31.64
+8192                   36.89
+16384                  44.97
+32768                  69.52
+65536                 181.13
+131072                195.59
+262144                243.80
+524288                360.93
+1048576               582.38
+2097152              1022.27
+4194304              1857.83
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-002,flux-015"]}}, "user": {"study_id": "osu-2-iter-14"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925830.294137,"name":"init"}
+{"timestamp":1742925830.2952838,"name":"starting"}
+{"timestamp":1742925830.3154845,"name":"shell.init","context":{"service":"501043911-shell-f4u9iWqjd","leader-rank":1,"size":2}}
+{"timestamp":1742925830.3195326,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925849.4142919,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2457,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925849.4190803,"name":"complete","context":{"status":0}}
+{"timestamp":1742925849.4191146,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-14-8934823821312.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-14-8934823821312.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.17
+2                       0.37
+4                       0.78
+8                       1.19
+16                      3.59
+32                      8.29
+64                     18.96
+128                    38.94
+256                    76.36
+512                   144.31
+1024                  277.68
+2048                  508.15
+4096                  850.63
+8192                 1286.11
+16384                1812.51
+32768                2136.46
+65536                2178.05
+131072               2021.31
+262144               1965.24
+524288               1877.03
+1048576              1883.65
+2097152              1884.54
+4194304              1922.82
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-002,flux-015"]}}, "user": {"study_id": "osu-2-iter-14"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925849.6998258,"name":"init"}
+{"timestamp":1742925849.7010524,"name":"starting"}
+{"timestamp":1742925849.723011,"name":"shell.init","context":{"service":"501043911-shell-f53hknYVM","leader-rank":1,"size":2}}
+{"timestamp":1742925849.7272623,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925858.3040364,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2497,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925858.3102148,"name":"complete","context":{"status":0}}
+{"timestamp":1742925858.3102531,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-15-9084023603200.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-15-9084023603200.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      24.67
+1                      24.56
+2                      24.60
+4                      24.45
+8                      25.18
+16                     24.51
+32                     24.73
+64                     24.54
+128                    25.02
+256                    26.09
+512                    25.86
+1024                   26.37
+2048                   30.35
+4096                   32.54
+8192                   38.37
+16384                  49.56
+32768                  75.89
+65536                 193.08
+131072                207.08
+262144                248.89
+524288                362.40
+1048576               564.09
+2097152               957.41
+4194304              1807.16
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-002,flux-007"]}}, "user": {"study_id": "osu-2-iter-15"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925858.5942049,"name":"init"}
+{"timestamp":1742925858.5953352,"name":"starting"}
+{"timestamp":1742925858.6155143,"name":"shell.init","context":{"service":"501043911-shell-f57d54Rbu","leader-rank":1,"size":2}}
+{"timestamp":1742925858.619523,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925877.6560807,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2537,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925877.66101,"name":"complete","context":{"status":0}}
+{"timestamp":1742925877.6610458,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-15-9408746618880.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-15-9408746618880.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.16
+2                       0.35
+4                       0.96
+8                       1.37
+16                      3.54
+32                      8.35
+64                     21.07
+128                    39.71
+256                    75.19
+512                   148.79
+1024                  284.35
+2048                  528.70
+4096                  853.51
+8192                 1401.02
+16384                1893.57
+32768                2230.74
+65536                2288.80
+131072               2217.00
+262144               2084.72
+524288               2010.87
+1048576              1881.37
+2097152              1907.54
+4194304              1884.17
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-002,flux-007"]}}, "user": {"study_id": "osu-2-iter-15"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925877.9488947,"name":"init"}
+{"timestamp":1742925877.9501405,"name":"starting"}
+{"timestamp":1742925877.9720602,"name":"shell.init","context":{"service":"501043911-shell-f5G9oikz3","leader-rank":1,"size":2}}
+{"timestamp":1742925877.9762571,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925886.4433722,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2577,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925886.4511724,"name":"complete","context":{"status":0}}
+{"timestamp":1742925886.4512067,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-16-9556134461440.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-16-9556134461440.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      29.30
+1                      28.88
+2                      28.64
+4                      28.84
+8                      28.88
+16                     28.72
+32                     29.39
+64                     29.07
+128                    29.13
+256                    29.98
+512                    30.90
+1024                   31.74
+2048                   35.70
+4096                   38.53
+8192                   45.13
+16384                  59.92
+32768                  90.95
+65536                 232.02
+131072                250.35
+262144                313.61
+524288                446.15
+1048576               690.20
+2097152              1178.38
+4194304              2030.02
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-002,flux-008"]}}, "user": {"study_id": "osu-2-iter-16"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925886.732815,"name":"init"}
+{"timestamp":1742925886.7339687,"name":"starting"}
+{"timestamp":1742925886.7537014,"name":"shell.init","context":{"service":"501043911-shell-f5L2MsyfM","leader-rank":1,"size":2}}
+{"timestamp":1742925886.7580392,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925908.9730899,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2616,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925908.9799597,"name":"complete","context":{"status":0}}
+{"timestamp":1742925908.9799931,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-16-9934141915136.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-16-9934141915136.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.17
+2                       0.39
+4                       0.70
+8                       1.38
+16                      2.66
+32                     10.52
+64                     20.71
+128                    38.40
+256                    70.37
+512                   134.01
+1024                  255.93
+2048                  455.08
+4096                  765.54
+8192                 1234.48
+16384                1493.68
+32768                1704.38
+65536                1782.12
+131072               1731.54
+262144               1653.05
+524288               1755.83
+1048576              1660.15
+2097152              1690.69
+4194304              1651.96
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-002,flux-008"]}}, "user": {"study_id": "osu-2-iter-16"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925909.2645895,"name":"init"}
+{"timestamp":1742925909.2658587,"name":"starting"}
+{"timestamp":1742925909.287257,"name":"shell.init","context":{"service":"501043911-shell-f5VxH6z4f","leader-rank":1,"size":2}}
+{"timestamp":1742925909.291486,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925918.7177618,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2657,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925918.7284536,"name":"complete","context":{"status":0}}
+{"timestamp":1742925918.7284844,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-17-10097702993920.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-17-10097702993920.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      23.41
+1                      23.93
+2                      23.41
+4                      23.40
+8                      23.49
+16                     23.48
+32                     23.57
+64                     23.54
+128                    23.63
+256                    24.45
+512                    24.52
+1024                   25.38
+2048                   28.99
+4096                   31.55
+8192                   37.89
+16384                  48.72
+32768                  77.24
+65536                 186.63
+131072                203.80
+262144                251.19
+524288                368.92
+1048576               586.08
+2097152               976.41
+4194304              1694.58
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-002,flux-014"]}}, "user": {"study_id": "osu-2-iter-17"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925919.0131526,"name":"init"}
+{"timestamp":1742925919.014322,"name":"starting"}
+{"timestamp":1742925919.0352294,"name":"shell.init","context":{"service":"501043911-shell-f5aFUSGQP","leader-rank":1,"size":2}}
+{"timestamp":1742925919.0392156,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925937.5751932,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2697,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925937.5815682,"name":"complete","context":{"status":0}}
+{"timestamp":1742925937.5815995,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-17-10414138064896.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-17-10414138064896.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.19
+2                       0.44
+4                       0.82
+8                       1.46
+16                      3.39
+32                      5.60
+64                     11.72
+128                    43.00
+256                    83.60
+512                   156.47
+1024                  293.30
+2048                  530.72
+4096                  895.16
+8192                 1404.97
+16384                1916.34
+32768                2183.84
+65536                2217.05
+131072               2131.82
+262144               1893.25
+524288               1917.76
+1048576              1872.15
+2097152              1922.34
+4194304              1871.59
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-002,flux-014"]}}, "user": {"study_id": "osu-2-iter-17"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925937.8744855,"name":"init"}
+{"timestamp":1742925937.8757641,"name":"starting"}
+{"timestamp":1742925937.8962796,"name":"shell.init","context":{"service":"501043911-shell-f5iZaiiaB","leader-rank":1,"size":2}}
+{"timestamp":1742925937.9006867,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925946.4316347,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2737,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925946.4371202,"name":"complete","context":{"status":0}}
+{"timestamp":1742925946.4371524,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-18-10562448654336.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-18-10562448654336.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      23.45
+1                      23.36
+2                      23.78
+4                      23.88
+8                      23.76
+16                     23.51
+32                     23.83
+64                     23.80
+128                    23.82
+256                    23.52
+512                    24.04
+1024                   25.42
+2048                   29.08
+4096                   31.18
+8192                   36.30
+16384                  45.58
+32768                  72.69
+65536                 184.65
+131072                199.78
+262144                255.55
+524288                379.90
+1048576               596.18
+2097152              1006.20
+4194304              1824.08
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-001,flux-015"]}}, "user": {"study_id": "osu-2-iter-18"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925946.7151394,"name":"init"}
+{"timestamp":1742925946.7163079,"name":"starting"}
+{"timestamp":1742925946.7371676,"name":"shell.init","context":{"service":"501043911-shell-f5nTYRFkT","leader-rank":0,"size":2}}
+{"timestamp":1742925946.7408869,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925965.6181936,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2736,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925965.6220899,"name":"complete","context":{"status":0}}
+{"timestamp":1742925965.6221209,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-18-10884403429376.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-18-10884403429376.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.20
+2                       0.42
+4                       0.75
+8                       1.61
+16                      2.86
+32                      6.86
+64                     17.28
+128                    37.48
+256                    72.94
+512                   138.19
+1024                  270.37
+2048                  495.81
+4096                  821.87
+8192                 1330.29
+16384                1831.16
+32768                2222.39
+65536                2191.11
+131072               2089.34
+262144               2058.41
+524288               1978.09
+1048576              1868.87
+2097152              1891.30
+4194304              1869.87
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-001,flux-015"]}}, "user": {"study_id": "osu-2-iter-18"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925965.9052546,"name":"init"}
+{"timestamp":1742925965.9065895,"name":"starting"}
+{"timestamp":1742925965.9266202,"name":"shell.init","context":{"service":"501043911-shell-f5vv4Tddh","leader-rank":0,"size":2}}
+{"timestamp":1742925965.9302037,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925974.508687,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2780,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925974.5121753,"name":"complete","context":{"status":0}}
+{"timestamp":1742925974.5122051,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-19-11033536102400.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-19-11033536102400.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      27.81
+1                      27.88
+2                      27.31
+4                      27.81
+8                      27.40
+16                     27.46
+32                     27.97
+64                     27.62
+128                    28.16
+256                    28.16
+512                    29.50
+1024                   28.75
+2048                   33.37
+4096                   35.31
+8192                   41.53
+16384                  49.66
+32768                  72.36
+65536                 196.73
+131072                206.73
+262144                257.70
+524288                378.92
+1048576               596.82
+2097152               995.70
+4194304              1890.62
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-001,flux-007"]}}, "user": {"study_id": "osu-2-iter-19"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925974.7935095,"name":"init"}
+{"timestamp":1742925974.7947252,"name":"starting"}
+{"timestamp":1742925974.8142626,"name":"shell.init","context":{"service":"501043911-shell-f5zqGoZcs","leader-rank":0,"size":2}}
+{"timestamp":1742925974.818059,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925995.1211171,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2823,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925995.1250856,"name":"complete","context":{"status":0}}
+{"timestamp":1742925995.1251132,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-19-11379431964672.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-19-11379431964672.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.18
+2                       0.30
+4                       0.75
+8                       1.31
+16                      3.10
+32                      6.75
+64                     17.22
+128                    39.10
+256                    75.58
+512                   142.10
+1024                  268.41
+2048                  498.17
+4096                  808.30
+8192                 1311.47
+16384                1812.84
+32768                2108.20
+65536                2243.81
+131072               2099.00
+262144               1988.31
+524288               1906.67
+1048576              1898.88
+2097152              1922.79
+4194304              1890.61
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-001,flux-007"]}}, "user": {"study_id": "osu-2-iter-19"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925995.4104867,"name":"init"}
+{"timestamp":1742925995.4121799,"name":"starting"}
+{"timestamp":1742925995.4313812,"name":"shell.init","context":{"service":"501043911-shell-f69vGSGeB","leader-rank":0,"size":2}}
+{"timestamp":1742925995.4350026,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926003.9627743,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2866,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926003.9665563,"name":"complete","context":{"status":0}}
+{"timestamp":1742926003.9665852,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-2-2212545691648.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-2-2212545691648.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      27.03
+1                      27.25
+2                      27.11
+4                      27.06
+8                      27.21
+16                     26.82
+32                     27.15
+64                     26.74
+128                    27.36
+256                    27.27
+512                    27.46
+1024                   27.94
+2048                   32.28
+4096                   34.27
+8192                   39.83
+16384                  50.28
+32768                  73.68
+65536                 195.98
+131072                208.34
+262144                263.75
+524288                389.63
+1048576               619.44
+2097152              1064.67
+4194304              1933.95
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-001"]}}, "user": {"study_id": "osu-2-iter-2"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925449.0203269,"name":"init"}
+{"timestamp":1742925449.0212584,"name":"starting"}
+{"timestamp":1742925449.0424368,"name":"shell.init","context":{"service":"501043911-shell-f217x61CB","leader-rank":0,"size":2}}
+{"timestamp":1742925449.0817955,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925475.3051658,"name":"shell.task-exit","context":{"localid":0,"rank":1,"state":"Exited","pid":2408,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925475.3353009,"name":"complete","context":{"status":0}}
+{"timestamp":1742925475.3353338,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-2-2658551201792.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-2-2658551201792.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.19
+2                       0.39
+4                       0.79
+8                       1.44
+16                      2.88
+32                      8.17
+64                     20.80
+128                    39.01
+256                    74.80
+512                   139.36
+1024                  277.36
+2048                  473.76
+4096                  799.27
+8192                 1280.67
+16384                1559.72
+32768                1850.81
+65536                2162.48
+131072               2034.77
+262144               1821.24
+524288               1656.34
+1048576              1729.38
+2097152              1794.47
+4194304              1768.03
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-001"]}}, "user": {"study_id": "osu-2-iter-2"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925475.6056073,"name":"init"}
+{"timestamp":1742925475.6066189,"name":"starting"}
+{"timestamp":1742925475.6265845,"name":"shell.init","context":{"service":"501043911-shell-f2CqU4pm5","leader-rank":0,"size":2}}
+{"timestamp":1742925475.6303861,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925484.6469703,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2340,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925484.6536012,"name":"complete","context":{"status":0}}
+{"timestamp":1742925484.6536329,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-20-11527625113600.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-20-11527625113600.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      24.63
+1                      24.38
+2                      24.59
+4                      24.31
+8                      23.81
+16                     24.48
+32                     24.32
+64                     23.71
+128                    23.98
+256                    24.39
+512                    24.37
+1024                   25.39
+2048                   29.40
+4096                   32.54
+8192                   39.30
+16384                  51.72
+32768                  79.60
+65536                 202.63
+131072                225.38
+262144                294.72
+524288                422.25
+1048576               693.97
+2097152              1201.38
+4194304              1937.60
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-001,flux-008"]}}, "user": {"study_id": "osu-2-iter-20"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926004.2437582,"name":"init"}
+{"timestamp":1742926004.2450287,"name":"starting"}
+{"timestamp":1742926004.2666144,"name":"shell.init","context":{"service":"501043911-shell-f6Dp3ktr3","leader-rank":0,"size":2}}
+{"timestamp":1742926004.2703021,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926024.4936953,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2909,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926024.4985304,"name":"complete","context":{"status":0}}
+{"timestamp":1742926024.4985592,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-20-11872027803648.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-20-11872027803648.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.16
+2                       0.31
+4                       0.84
+8                       1.17
+16                      2.83
+32                      7.13
+64                     19.16
+128                    40.24
+256                    76.73
+512                   142.99
+1024                  277.06
+2048                  480.80
+4096                  730.61
+8192                 1208.58
+16384                1613.47
+32768                2045.08
+65536                2223.03
+131072               2061.73
+262144               1778.78
+524288               1790.68
+1048576              1719.24
+2097152              1700.66
+4194304              1675.59
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-001,flux-008"]}}, "user": {"study_id": "osu-2-iter-20"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926024.7717426,"name":"init"}
+{"timestamp":1742926024.7730486,"name":"starting"}
+{"timestamp":1742926024.7940462,"name":"shell.init","context":{"service":"501043911-shell-f6NrmShnf","leader-rank":0,"size":2}}
+{"timestamp":1742926024.7977526,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926034.1332924,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2952,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926034.139744,"name":"complete","context":{"status":0}}
+{"timestamp":1742926034.139775,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-21-12033860829184.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-21-12033860829184.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      25.85
+1                      25.24
+2                      26.05
+4                      25.47
+8                      25.64
+16                     25.21
+32                     25.85
+64                     25.73
+128                    25.55
+256                    25.97
+512                    25.85
+1024                   26.56
+2048                   31.05
+4096                   32.69
+8192                   38.25
+16384                  48.56
+32768                  70.96
+65536                 185.23
+131072                196.70
+262144                244.67
+524288                361.59
+1048576               585.76
+2097152              1003.51
+4194304              1797.16
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-001,flux-014"]}}, "user": {"study_id": "osu-2-iter-21"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926034.4173503,"name":"init"}
+{"timestamp":1742926034.4185801,"name":"starting"}
+{"timestamp":1742926034.4389894,"name":"shell.init","context":{"service":"501043911-shell-f6T7L5G6s","leader-rank":0,"size":2}}
+{"timestamp":1742926034.4426699,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926053.7960844,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2995,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926053.7999959,"name":"complete","context":{"status":0}}
+{"timestamp":1742926053.8000236,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-21-12363650564096.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-21-12363650564096.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.17
+2                       0.40
+4                       0.67
+8                       1.46
+16                      3.45
+32                      6.17
+64                     16.55
+128                    38.64
+256                    74.87
+512                   144.54
+1024                  275.74
+2048                  509.23
+4096                  831.71
+8192                 1359.15
+16384                1870.13
+32768                2238.34
+65536                2097.35
+131072               2176.76
+262144               1962.42
+524288               2007.67
+1048576              1925.02
+2097152              1895.42
+4194304              1882.85
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-001,flux-014"]}}, "user": {"study_id": "osu-2-iter-21"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926054.0758181,"name":"init"}
+{"timestamp":1742926054.0772355,"name":"starting"}
+{"timestamp":1742926054.0972481,"name":"shell.init","context":{"service":"501043911-shell-f6bmnTrb9","leader-rank":0,"size":2}}
+{"timestamp":1742926054.1009438,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926062.6542017,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":3039,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926062.6578267,"name":"complete","context":{"status":0}}
+{"timestamp":1742926062.657855,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-22-12512414138368.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-22-12512414138368.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      22.82
+1                      23.18
+2                      22.71
+4                      22.56
+8                      22.75
+16                     22.60
+32                     22.75
+64                     22.61
+128                    22.77
+256                    23.16
+512                    23.83
+1024                   23.84
+2048                   27.33
+4096                   29.00
+8192                   33.72
+16384                  42.85
+32768                  64.45
+65536                 170.09
+131072                180.47
+262144                227.48
+524288                338.85
+1048576               549.09
+2097152               946.49
+4194304              1672.37
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-015,flux-007"]}}, "user": {"study_id": "osu-2-iter-22"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926062.9423044,"name":"init"}
+{"timestamp":1742926062.9436352,"name":"starting"}
+{"timestamp":1742926062.9646623,"name":"shell.init","context":{"service":"501043911-shell-f6fgSC4Nj","leader-rank":6,"size":2}}
+{"timestamp":1742926062.9689891,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926080.7040198,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2714,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926080.7094066,"name":"complete","context":{"status":0}}
+{"timestamp":1742926080.7094376,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-22-12815192555520.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-22-12815192555520.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.20
+2                       0.50
+4                       0.84
+8                       1.45
+16                      3.39
+32                      6.44
+64                     22.26
+128                    41.58
+256                    78.93
+512                   151.64
+1024                  294.27
+2048                  540.46
+4096                  892.96
+8192                 1367.09
+16384                1662.82
+32768                1947.83
+65536                2155.06
+131072               2127.10
+262144               2073.47
+524288               2007.76
+1048576              1907.89
+2097152              1885.20
+4194304              1847.36
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-015,flux-007"]}}, "user": {"study_id": "osu-2-iter-22"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926080.9887705,"name":"init"}
+{"timestamp":1742926080.9900813,"name":"starting"}
+{"timestamp":1742926081.0100379,"name":"shell.init","context":{"service":"501043911-shell-f6odjgb9q","leader-rank":6,"size":2}}
+{"timestamp":1742926081.0141461,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926089.5299897,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2757,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926089.5366409,"name":"complete","context":{"status":0}}
+{"timestamp":1742926089.5366726,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-23-12963167600640.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-23-12963167600640.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      27.28
+1                      26.71
+2                      26.74
+4                      26.74
+8                      26.50
+16                     26.89
+32                     27.00
+64                     27.13
+128                    26.72
+256                    27.91
+512                    28.04
+1024                   28.70
+2048                   33.15
+4096                   35.72
+8192                   42.13
+16384                  55.32
+32768                  86.18
+65536                 220.14
+131072                243.56
+262144                313.90
+524288                449.54
+1048576               716.07
+2097152              1226.60
+4194304              1985.44
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-015,flux-008"]}}, "user": {"study_id": "osu-2-iter-23"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926089.8091595,"name":"init"}
+{"timestamp":1742926089.8104398,"name":"starting"}
+{"timestamp":1742926089.8325832,"name":"shell.init","context":{"service":"501043911-shell-f6sXBjNhD","leader-rank":7,"size":2}}
+{"timestamp":1742926089.8372087,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926111.3015974,"name":"shell.task-exit","context":{"localid":0,"rank":1,"state":"Exited","pid":2494,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926111.3101554,"name":"complete","context":{"status":0}}
+{"timestamp":1742926111.3101883,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-23-13328575365120.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-23-13328575365120.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.17
+2                       0.37
+4                       0.68
+8                       1.25
+16                      2.61
+32                      6.80
+64                     17.84
+128                    35.19
+256                    68.17
+512                   125.33
+1024                  243.80
+2048                  422.87
+4096                  696.47
+8192                 1052.05
+16384                1416.28
+32768                1741.71
+65536                1810.92
+131072               1935.68
+262144               1838.10
+524288               1723.74
+1048576              1661.09
+2097152              1666.06
+4194304              1632.54
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-015,flux-008"]}}, "user": {"study_id": "osu-2-iter-23"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926111.5892451,"name":"init"}
+{"timestamp":1742926111.5906811,"name":"starting"}
+{"timestamp":1742926111.6149061,"name":"shell.init","context":{"service":"501043911-shell-f737uZgTZ","leader-rank":7,"size":2}}
+{"timestamp":1742926111.6200736,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926121.1643593,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2462,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926121.1687407,"name":"complete","context":{"status":0}}
+{"timestamp":1742926121.1687701,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-24-13494132932608.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-24-13494132932608.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      23.54
+1                      23.80
+2                      23.88
+4                      23.85
+8                      23.56
+16                     23.57
+32                     23.49
+64                     23.28
+128                    23.62
+256                    25.01
+512                    25.23
+1024                   25.78
+2048                   29.09
+4096                   31.21
+8192                   36.50
+16384                  47.69
+32768                  72.82
+65536                 182.14
+131072                198.10
+262144                252.81
+524288                367.57
+1048576               578.79
+2097152               995.23
+4194304              1800.05
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-015,flux-014"]}}, "user": {"study_id": "osu-2-iter-24"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926121.457026,"name":"init"}
+{"timestamp":1742926121.458452,"name":"starting"}
+{"timestamp":1742926121.4803393,"name":"shell.init","context":{"service":"501043911-shell-f77U9KVLK","leader-rank":13,"size":2}}
+{"timestamp":1742926121.4844842,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926140.2769773,"name":"shell.task-exit","context":{"localid":0,"rank":1,"state":"Exited","pid":2574,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926140.283926,"name":"complete","context":{"status":0}}
+{"timestamp":1742926140.2839596,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-24-13814728753152.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-24-13814728753152.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.19
+2                       0.35
+4                       0.75
+8                       1.43
+16                      2.52
+32                      6.85
+64                     18.58
+128                    36.37
+256                    75.23
+512                   142.20
+1024                  261.86
+2048                  489.69
+4096                  773.83
+8192                 1248.05
+16384                1757.94
+32768                2258.15
+65536                2457.09
+131072               2240.27
+262144               2097.74
+524288               2032.99
+1048576              1930.78
+2097152              1959.38
+4194304              1899.45
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-015,flux-014"]}}, "user": {"study_id": "osu-2-iter-24"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926140.5659652,"name":"init"}
+{"timestamp":1742926140.5674939,"name":"starting"}
+{"timestamp":1742926140.589046,"name":"shell.init","context":{"service":"501043911-shell-f7FtbGsPd","leader-rank":13,"size":2}}
+{"timestamp":1742926140.593245,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926149.0224042,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2627,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926149.0280926,"name":"complete","context":{"status":0}}
+{"timestamp":1742926149.0281281,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-25-13961428729856.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-25-13961428729856.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      28.54
+1                      29.03
+2                      29.08
+4                      28.70
+8                      28.66
+16                     29.03
+32                     28.88
+64                     28.78
+128                    29.41
+256                    30.07
+512                    30.45
+1024                   31.93
+2048                   35.97
+4096                   38.20
+8192                   45.31
+16384                  59.15
+32768                  89.17
+65536                 228.95
+131072                241.93
+262144                315.46
+524288                434.12
+1048576               648.00
+2097152              1088.15
+4194304              1892.37
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-007,flux-008"]}}, "user": {"study_id": "osu-2-iter-25"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926149.3106158,"name":"init"}
+{"timestamp":1742926149.3120353,"name":"starting"}
+{"timestamp":1742926149.3322611,"name":"shell.init","context":{"service":"501043911-shell-f7Kk6ebWo","leader-rank":6,"size":2}}
+{"timestamp":1742926149.336334,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926170.8896086,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2797,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926170.8987927,"name":"complete","context":{"status":0}}
+{"timestamp":1742926170.8988254,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-25-14328363220992.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-25-14328363220992.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.19
+2                       0.30
+4                       0.70
+8                       1.53
+16                      3.86
+32                      9.98
+64                     19.98
+128                    39.66
+256                    75.59
+512                   146.19
+1024                  273.42
+2048                  494.38
+4096                  786.84
+8192                 1228.56
+16384                1376.06
+32768                1725.51
+65536                1812.93
+131072               1691.16
+262144               1797.88
+524288               1744.83
+1048576              1698.43
+2097152              1695.79
+4194304              1655.29
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-007,flux-008"]}}, "user": {"study_id": "osu-2-iter-25"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926171.1812854,"name":"init"}
+{"timestamp":1742926171.1828082,"name":"starting"}
+{"timestamp":1742926171.2027009,"name":"shell.init","context":{"service":"501043911-shell-f7VP9PmvX","leader-rank":6,"size":2}}
+{"timestamp":1742926171.2070358,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926180.5871975,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2838,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926180.6033785,"name":"complete","context":{"status":0}}
+{"timestamp":1742926180.6034138,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-26-14491337097216.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-26-14491337097216.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      24.53
+1                      24.64
+2                      24.66
+4                      24.37
+8                      24.50
+16                     24.70
+32                     24.61
+64                     24.44
+128                    24.64
+256                    25.57
+512                    26.01
+1024                   26.06
+2048                   29.80
+4096                   31.94
+8192                   38.51
+16384                  53.00
+32768                  80.56
+65536                 198.78
+131072                202.64
+262144                250.21
+524288                359.50
+1048576               556.87
+2097152               937.83
+4194304              1649.45
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-007,flux-014"]}}, "user": {"study_id": "osu-2-iter-26"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926180.8954155,"name":"init"}
+{"timestamp":1742926180.8967872,"name":"starting"}
+{"timestamp":1742926180.9166,"name":"shell.init","context":{"service":"501043911-shell-f7ZfSqVQB","leader-rank":6,"size":2}}
+{"timestamp":1742926180.9202578,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926199.5007091,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2878,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926199.5069888,"name":"complete","context":{"status":0}}
+{"timestamp":1742926199.5070207,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-26-14808225153024.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-26-14808225153024.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.21
+2                       0.39
+4                       0.80
+8                       1.12
+16                      2.97
+32                      6.65
+64                     20.84
+128                    41.07
+256                    77.19
+512                   149.87
+1024                  278.50
+2048                  519.80
+4096                  844.34
+8192                 1368.50
+16384                1881.02
+32768                2218.35
+65536                2275.77
+131072               2111.85
+262144               2013.30
+524288               1902.03
+1048576              1881.31
+2097152              1850.55
+4194304              1874.88
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-007,flux-014"]}}, "user": {"study_id": "osu-2-iter-26"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926199.7834027,"name":"init"}
+{"timestamp":1742926199.7848771,"name":"starting"}
+{"timestamp":1742926199.8047128,"name":"shell.init","context":{"service":"501043911-shell-f7hzF9cBH","leader-rank":6,"size":2}}
+{"timestamp":1742926199.8085051,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926208.4161189,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2918,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926208.4221385,"name":"complete","context":{"status":0}}
+{"timestamp":1742926208.422173,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-27-14957760479232.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-27-14957760479232.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      25.53
+1                      25.01
+2                      25.34
+4                      24.99
+8                      24.79
+16                     24.61
+32                     25.58
+64                     25.16
+128                    25.60
+256                    26.09
+512                    26.73
+1024                   27.23
+2048                   31.06
+4096                   33.23
+8192                   39.73
+16384                  54.04
+32768                  84.53
+65536                 202.96
+131072                217.54
+262144                278.22
+524288                416.93
+1048576               674.67
+2097152              1127.28
+4194304              1879.34
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-008,flux-014"]}}, "user": {"study_id": "osu-2-iter-27"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926208.6960075,"name":"init"}
+{"timestamp":1742926208.6973486,"name":"starting"}
+{"timestamp":1742926208.7195375,"name":"shell.init","context":{"service":"501043911-shell-f7mv55Evj","leader-rank":7,"size":2}}
+{"timestamp":1742926208.7241838,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926228.9236574,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2582,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926228.9285676,"name":"complete","context":{"status":0}}
+{"timestamp":1742926228.9285991,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-27-15301844402176.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-27-15301844402176.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.20
+2                       0.29
+4                       0.75
+8                       1.36
+16                      2.76
+32                      6.70
+64                     18.18
+128                    35.57
+256                    71.67
+512                   133.68
+1024                  245.34
+2048                  450.73
+4096                  705.89
+8192                 1078.33
+16384                1439.25
+32768                1774.69
+65536                1797.09
+131072               2096.24
+262144               2190.32
+524288               1979.78
+1048576              1702.26
+2097152              1700.09
+4194304              1718.50
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-008,flux-014"]}}, "user": {"study_id": "osu-2-iter-27"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742926229.205286,"name":"init"}
+{"timestamp":1742926229.2067926,"name":"starting"}
+{"timestamp":1742926229.2308388,"name":"shell.init","context":{"service":"501043911-shell-f7vxJbHWo","leader-rank":7,"size":2}}
+{"timestamp":1742926229.2361166,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742926238.4728363,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2623,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742926238.4774468,"name":"complete","context":{"status":0}}
+{"timestamp":1742926238.4774806,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-3-2815032295424.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-3-2815032295424.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      21.63
+1                      21.45
+2                      21.65
+4                      21.53
+8                      21.52
+16                     21.68
+32                     21.66
+64                     21.65
+128                    22.14
+256                    22.16
+512                    22.33
+1024                   22.69
+2048                   26.40
+4096                   28.69
+8192                   34.00
+16384                  42.42
+32768                  65.92
+65536                 163.97
+131072                188.28
+262144                242.95
+524288                360.41
+1048576               596.62
+2097152              1010.83
+4194304              1880.23
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-015"]}}, "user": {"study_id": "osu-2-iter-3"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925484.9320936,"name":"init"}
+{"timestamp":1742925484.9330761,"name":"starting"}
+{"timestamp":1742925484.9559124,"name":"shell.init","context":{"service":"501043911-shell-f2GwsmLBH","leader-rank":8,"size":2}}
+{"timestamp":1742925484.9929686,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925509.201725,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2488,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925509.2342026,"name":"complete","context":{"status":0}}
+{"timestamp":1742925509.2342348,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-3-3227449819136.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-3-3227449819136.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.09
+2                       0.23
+4                       0.29
+8                       0.62
+16                      1.42
+32                      2.79
+64                      9.41
+128                    31.82
+256                    59.35
+512                   112.51
+1024                  214.08
+2048                  411.60
+4096                  717.23
+8192                 1178.63
+16384                1630.44
+32768                2111.82
+65536                2054.05
+131072               2374.39
+262144               2607.93
+524288               2667.23
+1048576              2695.55
+2097152              2735.36
+4194304              2838.27
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-015"]}}, "user": {"study_id": "osu-2-iter-3"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925509.5140383,"name":"init"}
+{"timestamp":1742925509.5150938,"name":"starting"}
+{"timestamp":1742925509.537946,"name":"shell.init","context":{"service":"501043911-shell-f2TnDgwZq","leader-rank":8,"size":2}}
+{"timestamp":1742925509.5423102,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925516.5368793,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2528,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925516.5411808,"name":"complete","context":{"status":0}}
+{"timestamp":1742925516.5412087,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-4-3350057713664.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-4-3350057713664.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      21.24
+1                      21.25
+2                      21.22
+4                      21.42
+8                      21.24
+16                     21.43
+32                     21.34
+64                     21.35
+128                    21.49
+256                    21.61
+512                    21.79
+1024                   22.42
+2048                   25.99
+4096                   27.91
+8192                   32.75
+16384                  41.81
+32768                  64.61
+65536                 162.26
+131072                179.94
+262144                228.23
+524288                342.42
+1048576               558.92
+2097152               937.63
+4194304              1660.05
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-007"]}}, "user": {"study_id": "osu-2-iter-4"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925516.8223193,"name":"init"}
+{"timestamp":1742925516.8233137,"name":"starting"}
+{"timestamp":1742925516.8431513,"name":"shell.init","context":{"service":"501043911-shell-f2X128T1q","leader-rank":6,"size":2}}
+{"timestamp":1742925516.8908441,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925541.0263035,"name":"shell.task-exit","context":{"localid":0,"rank":1,"state":"Exited","pid":2579,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925541.0428107,"name":"complete","context":{"status":0}}
+{"timestamp":1742925541.0428441,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-4-3761351163904.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-4-3761351163904.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.18
+2                       0.41
+4                       0.81
+8                       1.29
+16                      3.37
+32                      4.97
+64                     20.93
+128                    42.29
+256                    79.81
+512                   157.13
+1024                  296.00
+2048                  531.85
+4096                  874.60
+8192                 1399.75
+16384                1688.11
+32768                1975.22
+65536                2108.66
+131072               1967.30
+262144               1922.51
+524288               1905.20
+1048576              1798.88
+2097152              1811.07
+4194304              1777.59
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-007"]}}, "user": {"study_id": "osu-2-iter-4"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925541.3367395,"name":"init"}
+{"timestamp":1742925541.3378096,"name":"starting"}
+{"timestamp":1742925541.3576341,"name":"shell.init","context":{"service":"501043911-shell-f2hoeitXH","leader-rank":6,"size":2}}
+{"timestamp":1742925541.3619955,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925550.2704237,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2340,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925550.280684,"name":"complete","context":{"status":0}}
+{"timestamp":1742925550.2807155,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-5-3916137758720.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-5-3916137758720.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      27.10
+1                      27.50
+2                      27.69
+4                      27.38
+8                      27.31
+16                     27.22
+32                     27.64
+64                     27.16
+128                    27.45
+256                    28.75
+512                    29.12
+1024                   29.83
+2048                   34.26
+4096                   37.66
+8192                   43.94
+16384                  57.89
+32768                  89.40
+65536                 227.26
+131072                248.45
+262144                308.64
+524288                446.10
+1048576               704.10
+2097152              1223.95
+4194304              2098.94
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-008"]}}, "user": {"study_id": "osu-2-iter-5"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925550.563396,"name":"init"}
+{"timestamp":1742925550.5644269,"name":"starting"}
+{"timestamp":1742925550.5875568,"name":"shell.init","context":{"service":"501043911-shell-f2msUgeUf","leader-rank":7,"size":2}}
+{"timestamp":1742925550.6450036,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925579.4554887,"name":"shell.task-exit","context":{"localid":0,"rank":1,"state":"Exited","pid":2729,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925579.4709184,"name":"complete","context":{"status":0}}
+{"timestamp":1742925579.4709518,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-5-4405998911488.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-5-4405998911488.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.36
+4                       0.67
+8                       1.31
+16                      4.11
+32                      8.25
+64                     18.22
+128                    36.32
+256                    70.71
+512                   132.57
+1024                  244.07
+2048                  436.82
+4096                  670.24
+8192                 1034.66
+16384                1427.46
+32768                1783.15
+65536                1825.19
+131072               2022.18
+262144               1758.18
+524288               1666.47
+1048576              1589.92
+2097152              1585.99
+4194304              1528.37
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-008"]}}, "user": {"study_id": "osu-2-iter-5"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925579.7615561,"name":"init"}
+{"timestamp":1742925579.7626677,"name":"starting"}
+{"timestamp":1742925579.7850478,"name":"shell.init","context":{"service":"501043911-shell-f2zjp36gw","leader-rank":7,"size":2}}
+{"timestamp":1742925579.7898223,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925589.7329211,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2119,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925589.7386169,"name":"complete","context":{"status":0}}
+{"timestamp":1742925589.7386582,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-6-4578149924864.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-6-4578149924864.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      27.16
+1                      27.00
+2                      26.91
+4                      27.19
+8                      27.07
+16                     26.83
+32                     27.07
+64                     27.45
+128                    27.64
+256                    28.47
+512                    28.54
+1024                   29.37
+2048                   33.93
+4096                   35.92
+8192                   42.12
+16384                  53.76
+32768                  81.08
+65536                 202.94
+131072                206.87
+262144                262.43
+524288                390.79
+1048576               621.70
+2097152              1040.81
+4194304              1969.94
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-014"]}}, "user": {"study_id": "osu-2-iter-6"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925590.0225606,"name":"init"}
+{"timestamp":1742925590.0235779,"name":"starting"}
+{"timestamp":1742925590.0477507,"name":"shell.init","context":{"service":"501043911-shell-f35G6S3KD","leader-rank":8,"size":2}}
+{"timestamp":1742925590.1001017,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925616.7220817,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2808,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925616.777638,"name":"complete","context":{"status":0}}
+{"timestamp":1742925616.777688,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-6-5031638073344.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-6-5031638073344.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.16
+2                       0.45
+4                       0.54
+8                       1.42
+16                      2.95
+32                      8.78
+64                     19.07
+128                    37.32
+256                    71.63
+512                   134.17
+1024                  265.90
+2048                  491.14
+4096                  827.46
+8192                 1351.67
+16384                1782.28
+32768                2038.81
+65536                2114.64
+131072               1979.47
+262144               1944.71
+524288               1874.72
+1048576              1867.71
+2097152              1899.84
+4194304              1821.89
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-009,flux-014"]}}, "user": {"study_id": "osu-2-iter-6"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925617.0518954,"name":"init"}
+{"timestamp":1742925617.0529933,"name":"starting"}
+{"timestamp":1742925617.0746088,"name":"shell.init","context":{"service":"501043911-shell-f3HB1dLZu","leader-rank":8,"size":2}}
+{"timestamp":1742925617.0789049,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925625.8621526,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2847,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925625.866632,"name":"complete","context":{"status":0}}
+{"timestamp":1742925625.8666608,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-7-5184210075648.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-7-5184210075648.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      22.67
+1                      22.51
+2                      22.61
+4                      22.65
+8                      22.75
+16                     22.60
+32                     22.57
+64                     22.70
+128                    22.88
+256                    23.20
+512                    23.22
+1024                   23.93
+2048                   27.95
+4096                   29.17
+8192                   34.09
+16384                  43.04
+32768                  65.21
+65536                 168.24
+131072                179.41
+262144                224.70
+524288                347.30
+1048576               551.28
+2097152               951.32
+4194304              1683.21
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-002"]}}, "user": {"study_id": "osu-2-iter-7"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925626.1452804,"name":"init"}
+{"timestamp":1742925626.1463795,"name":"starting"}
+{"timestamp":1742925626.1680887,"name":"shell.init","context":{"service":"501043911-shell-f3MBTtjKm","leader-rank":1,"size":2}}
+{"timestamp":1742925626.1731269,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925644.0035334,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2287,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925644.0087016,"name":"complete","context":{"status":0}}
+{"timestamp":1742925644.0087314,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-7-5488649437184.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-7-5488649437184.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.17
+2                       0.33
+4                       0.91
+8                       1.53
+16                      3.49
+32                      6.69
+64                     21.64
+128                    41.77
+256                    80.01
+512                   151.59
+1024                  289.65
+2048                  534.11
+4096                  849.18
+8192                 1427.21
+16384                1987.24
+32768                2316.41
+65536                2378.86
+131072               2291.43
+262144               2190.48
+524288               2030.07
+1048576              2014.74
+2097152              2025.62
+4194304              2001.51
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-002"]}}, "user": {"study_id": "osu-2-iter-7"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925644.2918577,"name":"init"}
+{"timestamp":1742925644.2929776,"name":"starting"}
+{"timestamp":1742925644.3131356,"name":"shell.init","context":{"service":"501043911-shell-f3VBJA311","leader-rank":1,"size":2}}
+{"timestamp":1742925644.3174491,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925652.4945614,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2327,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925652.4996705,"name":"complete","context":{"status":0}}
+{"timestamp":1742925652.499717,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-8-5631020892160.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-8-5631020892160.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      25.45
+1                      25.21
+2                      25.08
+4                      25.06
+8                      25.08
+16                     25.23
+32                     25.66
+64                     25.67
+128                    26.18
+256                    25.98
+512                    26.02
+1024                   26.52
+2048                   30.19
+4096                   31.88
+8192                   37.08
+16384                  47.05
+32768                  69.93
+65536                 185.33
+131072                196.78
+262144                253.91
+524288                375.43
+1048576               591.62
+2097152              1012.05
+4194304              1806.58
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-001"]}}, "user": {"study_id": "osu-2-iter-8"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925652.7781718,"name":"init"}
+{"timestamp":1742925652.7792549,"name":"starting"}
+{"timestamp":1742925652.7979727,"name":"shell.init","context":{"service":"501043911-shell-f3YvD2xRD","leader-rank":0,"size":2}}
+{"timestamp":1742925652.8016801,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925672.3400123,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2420,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925672.3438344,"name":"complete","context":{"status":0}}
+{"timestamp":1742925672.3438652,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-8-5963847303168.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-8-5963847303168.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.24
+2                       0.29
+4                       0.65
+8                       0.92
+16                      3.44
+32                      6.85
+64                     19.13
+128                    39.20
+256                    75.53
+512                   144.23
+1024                  277.62
+2048                  509.24
+4096                  805.59
+8192                 1321.98
+16384                1768.57
+32768                2140.78
+65536                2200.25
+131072               2090.59
+262144               2032.95
+524288               1963.73
+1048576              1853.22
+2097152              1870.36
+4194304              1884.28
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-001"]}}, "user": {"study_id": "osu-2-iter-8"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925672.6162937,"name":"init"}
+{"timestamp":1742925672.6174567,"name":"starting"}
+{"timestamp":1742925672.6375687,"name":"shell.init","context":{"service":"501043911-shell-f3hfHmJuu","leader-rank":0,"size":2}}
+{"timestamp":1742925672.6410954,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925681.2519772,"name":"shell.task-exit","context":{"localid":0,"rank":1,"state":"Exited","pid":2687,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925681.2592909,"name":"complete","context":{"status":0}}
+{"timestamp":1742925681.2593248,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-9-6113533624320.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-9-6113533624320.out
@@ -1,0 +1,44 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Latency Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size          Latency (us)
+0                      25.91
+1                      25.91
+2                      25.81
+4                      25.71
+8                      26.05
+16                     25.76
+32                     25.80
+64                     25.92
+128                    25.87
+256                    26.19
+512                    26.41
+1024                   26.92
+2048                   30.47
+4096                   32.40
+8192                   37.40
+16384                  46.60
+32768                  67.94
+65536                 184.09
+131072                192.40
+262144                237.69
+524288                346.43
+1048576               553.39
+2097152               964.51
+4194304              1663.65
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-015"]}}, "user": {"study_id": "osu-2-iter-9"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925681.5385227,"name":"init"}
+{"timestamp":1742925681.5396557,"name":"starting"}
+{"timestamp":1742925681.5593567,"name":"shell.init","context":{"service":"501043911-shell-f3mbM2qCT","leader-rank":5,"size":2}}
+{"timestamp":1742925681.5631287,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925700.3640945,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2727,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925700.3706045,"name":"complete","context":{"status":0}}
+{"timestamp":1742925700.3706367,"name":"done"}
+

--- a/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-9-6434246885376.out
+++ b/experiments/google/compute-engine/gpu/size16/results/osu-fixed/osu-2-iter-9-6434246885376.out
@@ -1,0 +1,43 @@
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+Warning: OMB could not identify the local rank of the process.
+         This can lead to multiple processes using the same GPU.
+         Please use the get_local_rank script in the OMB repo for this.
+# OSU MPI-CUDA Bandwidth Test v5.8
+# Send Buffer on HOST (H) and Receive Buffer on HOST (H)
+# Size      Bandwidth (MB/s)
+1                       0.19
+2                       0.33
+4                       0.81
+8                       1.31
+16                      3.35
+32                      7.74
+64                     21.52
+128                    42.85
+256                    77.76
+512                   150.08
+1024                  291.44
+2048                  527.23
+4096                  886.79
+8192                 1428.16
+16384                1984.60
+32768                2304.45
+65536                2339.28
+131072               2129.06
+262144               2110.82
+524288               2033.87
+1048576              1960.49
+2097152              1951.93
+4194304              1914.97
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}, {"type": "gpu", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["singularity", "exec", "--nv", "/opt/containers/metric-osu-gpu_google-gpu.sif", "/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw", "-d", "cuda", "H", "H"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/containers", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": 0, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task", "gpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-006,flux-015"]}}, "user": {"study_id": "osu-2-iter-9"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742925700.6547399,"name":"init"}
+{"timestamp":1742925700.6558993,"name":"starting"}
+{"timestamp":1742925700.6751986,"name":"shell.init","context":{"service":"501043911-shell-f3v1yN8EB","leader-rank":5,"size":2}}
+{"timestamp":1742925700.6788123,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742925709.0205088,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":2776,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742925709.0285408,"name":"complete","context":{"status":0}}
+{"timestamp":1742925709.0285749,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/metadata/nodes-16-osu-redo.json
+++ b/experiments/google/gke/gpu/size16/metadata/nodes-16-osu-redo.json
@@ -1,0 +1,7162 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "6898352504284601213",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-1glq\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:57Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-1glq",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-1glq",
+                "resourceVersion": "3866",
+                "uid": "9843fe06-c5e4-4f0f-a8e3-5e882cfbc862"
+            },
+            "spec": {
+                "podCIDR": "10.96.14.0/24",
+                "podCIDRs": [
+                    "10.96.14.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-1glq"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.89",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.42.96.121",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-1glq",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:03Z",
+                        "lastTransitionTime": "2025-03-25T17:23:02Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:03Z",
+                        "lastTransitionTime": "2025-03-25T17:20:59Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:31Z",
+                        "lastTransitionTime": "2025-03-25T17:21:55Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:31Z",
+                        "lastTransitionTime": "2025-03-25T17:21:55Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:31Z",
+                        "lastTransitionTime": "2025-03-25T17:21:55Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:31Z",
+                        "lastTransitionTime": "2025-03-25T17:23:19Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172858664
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40759488
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34898257
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/proxy-agent@sha256:abf95907d2fdbc47cf1629de14b4d44675e8fac76a8b52e2613b92cee231791e"
+                        ],
+                        "sizeBytes": 28969868
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24863034
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:d460e6b5088332f62b990f8a1f7bf6d9eca7c3f41cb974e3db493d6b0fc4ad70"
+                        ],
+                        "sizeBytes": 24425624
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24313759
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24121917
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23881188
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22296061
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "eafff7b5-fb2b-4137-b011-bc4e0c51c71b",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "825190ee891d6f49cbd394527cc8d964",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "825190ee-891d-6f49-cbd3-94527cc8d964"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "4763299427942095741",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-1hs3\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:57Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-1hs3",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-1hs3",
+                "resourceVersion": "3706",
+                "uid": "21e22b70-ee99-4604-8591-2ebc37009b8b"
+            },
+            "spec": {
+                "podCIDR": "10.96.2.0/24",
+                "podCIDRs": [
+                    "10.96.2.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-1hs3"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.77",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.55.104.139",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-1hs3",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:00Z",
+                        "lastTransitionTime": "2025-03-25T17:22:57Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:19Z",
+                        "lastTransitionTime": "2025-03-25T17:21:55Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:19Z",
+                        "lastTransitionTime": "2025-03-25T17:21:55Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:19Z",
+                        "lastTransitionTime": "2025-03-25T17:21:55Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:19Z",
+                        "lastTransitionTime": "2025-03-25T17:23:18Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172858664
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40759488
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34897038
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/proxy-agent@sha256:abf95907d2fdbc47cf1629de14b4d44675e8fac76a8b52e2613b92cee231791e"
+                        ],
+                        "sizeBytes": 28969868
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24951828
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:d460e6b5088332f62b990f8a1f7bf6d9eca7c3f41cb974e3db493d6b0fc4ad70"
+                        ],
+                        "sizeBytes": 24425624
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24314779
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24123230
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23881188
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22297374
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "5204c1a8-7b60-470f-898e-edeebbc55310",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "57e568ffa7bd565a6af6ae9f6a9a0d73",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "57e568ff-a7bd-565a-6af6-ae9f6a9a0d73"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "3542235406735989629",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-2hqd\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:58Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-2hqd",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-2hqd",
+                "resourceVersion": "3737",
+                "uid": "f54af55d-c6b3-4fc6-9b6b-5a45fc360044"
+            },
+            "spec": {
+                "podCIDR": "10.96.13.0/24",
+                "podCIDRs": [
+                    "10.96.13.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-2hqd"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.88",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.28.122.202",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-2hqd",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:07Z",
+                        "lastTransitionTime": "2025-03-25T17:23:06Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:21:56Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:21:56Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:21:56Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:23:19Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172857492
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40760801
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34898257
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24863034
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24313759
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24121917
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23881188
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22297374
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:ff5d5abcc0cdd74d3ba43b0959b246c4432c14356b1414ce35d8feff820eb664"
+                        ],
+                        "sizeBytes": 18373482
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71"
+                        ],
+                        "sizeBytes": 16418575
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "682a37c2-de4c-4010-9616-77f9c6c443f5",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "78a1149d86a6b04eaeda65ef7f08a5ec",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "78a1149d-86a6-b04e-aeda-65ef7f08a5ec"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "9098008739231783805",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-6dc8\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:58Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-6dc8",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-6dc8",
+                "resourceVersion": "3738",
+                "uid": "c3d6ce42-666e-43a5-9051-d06e290d9126"
+            },
+            "spec": {
+                "podCIDR": "10.96.1.0/24",
+                "podCIDRs": [
+                    "10.96.1.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-6dc8"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.76",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "35.192.197.36",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-6dc8",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:06Z",
+                        "lastTransitionTime": "2025-03-25T17:23:04Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:22:01Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:22:01Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:22:01Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:23:20Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172858664
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40759488
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34897038
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24863034
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24313759
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24123230
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23879640
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22296061
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:ff5d5abcc0cdd74d3ba43b0959b246c4432c14356b1414ce35d8feff820eb664"
+                        ],
+                        "sizeBytes": 18373482
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71"
+                        ],
+                        "sizeBytes": 16418575
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "579abefe-5d09-48f0-89d8-3d926bdb154c",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "295cfc9fcaf27c6e5e9f169b3022302b",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "295cfc9f-caf2-7c6e-5e9f-169b3022302b"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "7116011761694628733",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-6jwr\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:57Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-6jwr",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-6jwr",
+                "resourceVersion": "4522",
+                "uid": "ae7436f4-9bea-4338-a8af-4a4653e5ca49"
+            },
+            "spec": {
+                "podCIDR": "10.96.6.0/24",
+                "podCIDRs": [
+                    "10.96.6.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-6jwr"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.81",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "104.154.42.170",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-6jwr",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:01Z",
+                        "lastTransitionTime": "2025-03-25T17:22:57Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:25:20Z",
+                        "lastTransitionTime": "2025-03-25T17:21:57Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:25:20Z",
+                        "lastTransitionTime": "2025-03-25T17:21:57Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:25:20Z",
+                        "lastTransitionTime": "2025-03-25T17:21:57Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:25:20Z",
+                        "lastTransitionTime": "2025-03-25T17:23:18Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172857492
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40760801
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34897038
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24863034
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24313759
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24121917
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23881188
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22297374
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "gcr.io/kubebuilder/kube-rbac-proxy@sha256:0df4ae70e3bd0feffcec8f5cdb428f4abe666b667af991269ec5cb0bbda65869",
+                            "gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0"
+                        ],
+                        "sizeBytes": 19194567
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:ff5d5abcc0cdd74d3ba43b0959b246c4432c14356b1414ce35d8feff820eb664"
+                        ],
+                        "sizeBytes": 18373482
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "8119a583-c2a6-436c-8307-14688125351b",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "4060eb46362dcbf81cbbe38433906f0a",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "4060eb46-362d-cbf8-1cbb-e38433906f0a"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "3789302060408593277",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-6kp8\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:57Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-6kp8",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-6kp8",
+                "resourceVersion": "3733",
+                "uid": "1c82f156-6c54-441e-948c-50ea2eec9755"
+            },
+            "spec": {
+                "podCIDR": "10.96.0.0/24",
+                "podCIDRs": [
+                    "10.96.0.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-6kp8"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.7",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.46.140.96",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-6kp8",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:03Z",
+                        "lastTransitionTime": "2025-03-25T17:23:02Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:21:55Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:21:55Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:21:55Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:23:19Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172858664
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40760801
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34898257
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24863034
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24313759
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24123230
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23881188
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22297374
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:ff5d5abcc0cdd74d3ba43b0959b246c4432c14356b1414ce35d8feff820eb664"
+                        ],
+                        "sizeBytes": 18373482
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71"
+                        ],
+                        "sizeBytes": 16418575
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "fd258f97-0a3f-45de-8a44-2c660c44c511",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "f122e614bc4b71f47955cbe2f2744924",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "f122e614-bc4b-71f4-7955-cbe2f2744924"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "6467594836711005053",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-7hbf\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:58Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-7hbf",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-7hbf",
+                "resourceVersion": "4117",
+                "uid": "515319f8-43cb-4133-86a0-d8fb7de9bbf8"
+            },
+            "spec": {
+                "podCIDR": "10.96.7.0/24",
+                "podCIDRs": [
+                    "10.96.7.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-7hbf"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.82",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.56.19.113",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-7hbf",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:08Z",
+                        "lastTransitionTime": "2025-03-25T17:23:07Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:51Z",
+                        "lastTransitionTime": "2025-03-25T17:22:03Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:51Z",
+                        "lastTransitionTime": "2025-03-25T17:22:03Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:51Z",
+                        "lastTransitionTime": "2025-03-25T17:22:03Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:51Z",
+                        "lastTransitionTime": "2025-03-25T17:23:19Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172857492
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40759488
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34898257
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24951828
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24313759
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24121917
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23881188
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22297374
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:ff5d5abcc0cdd74d3ba43b0959b246c4432c14356b1414ce35d8feff820eb664"
+                        ],
+                        "sizeBytes": 18373482
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71"
+                        ],
+                        "sizeBytes": 16420466
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "80c1e10b-1ae0-424f-adc4-11af088a0499",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "4febb58f9835a38abcd43e4f746ac781",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "4febb58f-9835-a38a-bcd4-3e4f746ac781"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "1193886356029266813",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-cmr0\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:57Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-cmr0",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-cmr0",
+                "resourceVersion": "3569",
+                "uid": "d4880697-533f-4b35-94b4-a8d7649d8409"
+            },
+            "spec": {
+                "podCIDR": "10.96.5.0/24",
+                "podCIDRs": [
+                    "10.96.5.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-cmr0"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.80",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.31.85.32",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-cmr0",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:04Z",
+                        "lastTransitionTime": "2025-03-25T17:23:02Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:58Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:11Z",
+                        "lastTransitionTime": "2025-03-25T17:22:00Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:11Z",
+                        "lastTransitionTime": "2025-03-25T17:22:00Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:11Z",
+                        "lastTransitionTime": "2025-03-25T17:22:00Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:11Z",
+                        "lastTransitionTime": "2025-03-25T17:23:19Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172858664
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40760801
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34898257
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/proxy-agent@sha256:abf95907d2fdbc47cf1629de14b4d44675e8fac76a8b52e2613b92cee231791e"
+                        ],
+                        "sizeBytes": 28969868
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24863034
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:d460e6b5088332f62b990f8a1f7bf6d9eca7c3f41cb974e3db493d6b0fc4ad70"
+                        ],
+                        "sizeBytes": 24425624
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24313759
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24121917
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23881188
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22297374
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "93c971af-417b-424e-8b84-8ff3dd68600c",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "faf90e7bdbcf757f1497809af06e7ead",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "faf90e7b-dbcf-757f-1497-809af06e7ead"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "6726667959790427005",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-djqk\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:57Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-djqk",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-djqk",
+                "resourceVersion": "3716",
+                "uid": "81f86cbb-1f93-44bb-9382-0167d67f2ca6"
+            },
+            "spec": {
+                "podCIDR": "10.96.10.0/24",
+                "podCIDRs": [
+                    "10.96.10.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-djqk"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.85",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.122.128.234",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-djqk",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:22:59Z",
+                        "lastTransitionTime": "2025-03-25T17:22:57Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:54Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:22:00Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:22:00Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:22:00Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:23:19Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172858664
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40760801
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34898257
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24951828
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24314779
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24121917
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23879640
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22297374
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/metrics-server@sha256:cb17249a88fbbaeff5701654f5625a01d1faa0797faa6d463c121dde3fcc122f"
+                        ],
+                        "sizeBytes": 19267350
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:ff5d5abcc0cdd74d3ba43b0959b246c4432c14356b1414ce35d8feff820eb664"
+                        ],
+                        "sizeBytes": 18373482
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "28d5f031-c933-4274-95ab-4490e49f8a5a",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "b25a50a245e3bb84e3de5c2516495fc9",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "b25a50a2-45e3-bb84-e3de-5c2516495fc9"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "262515632670464892",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-fdgq\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:57Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-fdgq",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-fdgq",
+                "resourceVersion": "3846",
+                "uid": "78c548d5-9f91-4ece-8cc6-d78d32460fd3"
+            },
+            "spec": {
+                "podCIDR": "10.96.15.0/24",
+                "podCIDRs": [
+                    "10.96.15.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-fdgq"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.90",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.170.182.230",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-fdgq",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:01Z",
+                        "lastTransitionTime": "2025-03-25T17:22:57Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:29Z",
+                        "lastTransitionTime": "2025-03-25T17:22:02Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:29Z",
+                        "lastTransitionTime": "2025-03-25T17:22:02Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:29Z",
+                        "lastTransitionTime": "2025-03-25T17:22:02Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:29Z",
+                        "lastTransitionTime": "2025-03-25T17:23:18Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172858664
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40760801
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34898257
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/proxy-agent@sha256:abf95907d2fdbc47cf1629de14b4d44675e8fac76a8b52e2613b92cee231791e"
+                        ],
+                        "sizeBytes": 28969868
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24951828
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:d460e6b5088332f62b990f8a1f7bf6d9eca7c3f41cb974e3db493d6b0fc4ad70"
+                        ],
+                        "sizeBytes": 24425624
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24314779
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24123230
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23881188
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22297374
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "4f822318-6e61-4586-a588-2e482752cf05",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "74de04a5c0c597957cc663101eed1eb0",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "74de04a5-c0c5-9795-7cc6-63101eed1eb0"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "6168908813648747389",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-fq6g\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:57Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-fq6g",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-fq6g",
+                "resourceVersion": "3715",
+                "uid": "555b9368-300d-41cd-9fdc-ed5dca3e9079"
+            },
+            "spec": {
+                "podCIDR": "10.96.11.0/24",
+                "podCIDRs": [
+                    "10.96.11.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-fq6g"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.86",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.67.46.80",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-fq6g",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:03Z",
+                        "lastTransitionTime": "2025-03-25T17:23:00Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:21:57Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:21:57Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:21:57Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:23:19Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172858664
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40760801
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34898257
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/proxy-agent@sha256:abf95907d2fdbc47cf1629de14b4d44675e8fac76a8b52e2613b92cee231791e"
+                        ],
+                        "sizeBytes": 28969868
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24863034
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:d460e6b5088332f62b990f8a1f7bf6d9eca7c3f41cb974e3db493d6b0fc4ad70"
+                        ],
+                        "sizeBytes": 24425624
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24314779
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24123230
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23881188
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22296061
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "565d81b1-e6e3-4d2b-817c-a4bd22be6895",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "3e802df56ab689e11063cb486ae56966",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "3e802df5-6ab6-89e1-1063-cb486ae56966"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "1992587824537230205",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-hjmw\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:58Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-hjmw",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-hjmw",
+                "resourceVersion": "3735",
+                "uid": "56f2d9f1-572d-48cf-81ba-5e2a5fef7030"
+            },
+            "spec": {
+                "podCIDR": "10.96.9.0/24",
+                "podCIDRs": [
+                    "10.96.9.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-hjmw"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.84",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.67.32.161",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-hjmw",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:07Z",
+                        "lastTransitionTime": "2025-03-25T17:23:05Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:21:59Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:21:59Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:21:59Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:21Z",
+                        "lastTransitionTime": "2025-03-25T17:23:19Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172857492
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40760801
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34898257
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24863034
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24314779
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24123230
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23881188
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22297374
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:ff5d5abcc0cdd74d3ba43b0959b246c4432c14356b1414ce35d8feff820eb664"
+                        ],
+                        "sizeBytes": 18373482
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71"
+                        ],
+                        "sizeBytes": 16418575
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "06bbbc18-da80-4826-9538-82e24a95fd15",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "9bd2db141c4fe01fae66a39eaea50b7c",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "9bd2db14-1c4f-e01f-ae66-a39eaea50b7c"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "3449693816583314301",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-m0cq\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:57Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-m0cq",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-m0cq",
+                "resourceVersion": "3714",
+                "uid": "299d872b-ad7f-41e0-952c-0349405ee910"
+            },
+            "spec": {
+                "podCIDR": "10.96.12.0/24",
+                "podCIDRs": [
+                    "10.96.12.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-m0cq"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.87",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.58.111.44",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-m0cq",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:06Z",
+                        "lastTransitionTime": "2025-03-25T17:23:04Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:50Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:22:00Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:22:00Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:22:00Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:23:19Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172858664
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40760801
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34898257
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/proxy-agent@sha256:abf95907d2fdbc47cf1629de14b4d44675e8fac76a8b52e2613b92cee231791e"
+                        ],
+                        "sizeBytes": 28969868
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24863034
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:d460e6b5088332f62b990f8a1f7bf6d9eca7c3f41cb974e3db493d6b0fc4ad70"
+                        ],
+                        "sizeBytes": 24425624
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24314779
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24121917
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23879640
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22297374
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "f89bbeeb-5272-418c-bc33-f966e06bd8ea",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "3d9b9624ff7321ec6d221faa4e39f9a3",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "3d9b9624-ff73-21ec-6d22-1faa4e39f9a3"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "2240768828949617533",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-v77k\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:57Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-v77k",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-v77k",
+                "resourceVersion": "3720",
+                "uid": "1ef20b73-1c1d-4681-84f7-512682e07509"
+            },
+            "spec": {
+                "podCIDR": "10.96.3.0/24",
+                "podCIDRs": [
+                    "10.96.3.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-v77k"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.78",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.56.50.95",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-v77k",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:05Z",
+                        "lastTransitionTime": "2025-03-25T17:23:02Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:57Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:22:01Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:22:01Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:22:01Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:20Z",
+                        "lastTransitionTime": "2025-03-25T17:23:19Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172858664
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40760801
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/k8s-dns-dnsmasq-nanny@sha256:e178b753d49a90ec32f1f45e0f52ce64019641d3fd45d8deadcf08cb73b8c840"
+                        ],
+                        "sizeBytes": 37001839
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-to-sd@sha256:798127b7368b1a3a2851a6a336776739f32b0ed741d5d6ee07b97d6ac2998fa3"
+                        ],
+                        "sizeBytes": 35898621
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34897038
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/k8s-dns-kube-dns@sha256:b609a51c8aa4add2d1d0811737f177b4e944ea0781a48eead0d804722787f96f"
+                        ],
+                        "sizeBytes": 32667404
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/k8s-dns-sidecar@sha256:9e60f83b54d010a7dd7e5a868a6713ad410442c72f0b7540cda010c50651c0bc"
+                        ],
+                        "sizeBytes": 29112653
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/proxy-agent@sha256:abf95907d2fdbc47cf1629de14b4d44675e8fac76a8b52e2613b92cee231791e"
+                        ],
+                        "sizeBytes": 28969868
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:9678041ad0020efc360d4a9c0c616b48cc1224599545a103be3b2b853c521914"
+                        ],
+                        "sizeBytes": 25588923
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24951828
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:d460e6b5088332f62b990f8a1f7bf6d9eca7c3f41cb974e3db493d6b0fc4ad70"
+                        ],
+                        "sizeBytes": 24425624
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24313759
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24123230
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "bf17ccb7-6f63-4000-95a9-5fede846379f",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "c518cbd7050c5be3e89d7fe883200d98",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "c518cbd7-050c-5be3-e89d-7fe883200d98"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "8809783559990500221",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-wtl7\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:58Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-wtl7",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-wtl7",
+                "resourceVersion": "3864",
+                "uid": "fe314682-2e9d-4a43-9720-468d74217560"
+            },
+            "spec": {
+                "podCIDR": "10.96.4.0/24",
+                "podCIDRs": [
+                    "10.96.4.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-wtl7"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.79",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "35.224.214.55",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-wtl7",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:06Z",
+                        "lastTransitionTime": "2025-03-25T17:23:04Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:56Z",
+                        "lastTransitionTime": "2025-03-25T17:20:53Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:31Z",
+                        "lastTransitionTime": "2025-03-25T17:21:56Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:31Z",
+                        "lastTransitionTime": "2025-03-25T17:21:56Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:31Z",
+                        "lastTransitionTime": "2025-03-25T17:21:56Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:31Z",
+                        "lastTransitionTime": "2025-03-25T17:23:19Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172857492
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40759488
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34897038
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24951828
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "gcr.io/gke-release-staging/netd:v0.9.3-gke.6@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "asia.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c",
+                            "eu.gcr.io/gke-release-staging/netd@sha256:42eabe7305d0e842f39bc3ab19de150d36c2464e218368e775308c306c11478c"
+                        ],
+                        "sizeBytes": 24314779
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "gcr.io/gke-release-staging/cilium/hubble-cli:v0.13.5-gke.15@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-cli@sha256:05d7bdd7c0fa0c662a86ebf40d1d3b496320b3d4decc12d0f00a937ec55c8465"
+                        ],
+                        "sizeBytes": 24123230
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "gcr.io/gke-release-staging/anthos-networking/anetd-sidecar:v2.9.77@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "asia.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d",
+                            "eu.gcr.io/gke-release-staging/anthos-networking/anetd-sidecar@sha256:2a788f8b3fc1112f706a7b22f13fb0e430d76c5743e6f8a6c2c350345f3a006d"
+                        ],
+                        "sizeBytes": 23881188
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "gcr.io/gke-release-staging/cilium/hubble-relay:v1.15.6-gke1.31-gke.11@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "asia.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39",
+                            "eu.gcr.io/gke-release-staging/cilium/hubble-relay@sha256:0c146c28c89fc8ae7d0d949ac345e8678f7fae56be49b1ae35fc5e56459d5d39"
+                        ],
+                        "sizeBytes": 22297374
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-gpu-device-plugin@sha256:8bbd2bffa16a4ea1cf3eb1cf536eb18ea19e54aa899936a1ac4a079dbafc607b"
+                        ],
+                        "sizeBytes": 21050485
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/nvidia-partition-gpu@sha256:0f33d3c30ceafb6cc1d6eb2321a84b3b858aeac3725978cdcf69c3116a56d332"
+                        ],
+                        "sizeBytes": 19539959
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:12d99a6a72f4fecd689ead5d93001c1f3acea08ec72a55bbdfc070e0edc30fa4"
+                        ],
+                        "sizeBytes": 18654784
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-distroless/bash@sha256:ff5d5abcc0cdd74d3ba43b0959b246c4432c14356b1414ce35d8feff820eb664"
+                        ],
+                        "sizeBytes": 18373482
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "gcr.io/gke-release-staging/ip-masq-agent:v2.11.0-gke.30@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "asia.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71",
+                            "eu.gcr.io/gke-release-staging/ip-masq-agent@sha256:4035e9a6996d792ded07e94aab4e0a54bd3a3d58dddbbd0fb4edc8898a4c4d71"
+                        ],
+                        "sizeBytes": 16420466
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "9d190dae-d197-4a95-9020-d848b1aec302",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "c0b4e5c2474490a80b9d999d2cace07f",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "c0b4e5c2-4744-90a8-0b9d-999d2cace07f"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "container.googleapis.com/instance_id": "3037693959113497469",
+                    "csi.volume.kubernetes.io/nodeid": "{\"pd.csi.storage.gke.io\":\"projects/llnl-flux/zones/us-central1-a/instances/gke-gpu-cluster-16-default-pool-4f4915d2-xg1n\"}",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-accelerator=nvidia-tesla-v100,cloud.google.com/gke-boot-disk=pd-balanced,cloud.google.com/gke-container-runtime=containerd,cloud.google.com/gke-cpu-scaling-level=32,cloud.google.com/gke-gpu-driver-version=latest,cloud.google.com/gke-logging-variant=DEFAULT,cloud.google.com/gke-max-pods-per-node=110,cloud.google.com/gke-memory-gb-scaling-level=122,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos,cloud.google.com/gke-provisioning=standard,cloud.google.com/gke-stack-type=IPV4,cloud.google.com/machine-family=n1,cloud.google.com/private-node=false",
+                    "node.gke.io/last-applied-node-taints": "",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2025-03-25T17:22:57Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/instance-type": "n1-standard-32",
+                    "beta.kubernetes.io/os": "linux",
+                    "cloud.google.com/gke-accelerator": "nvidia-tesla-v100",
+                    "cloud.google.com/gke-boot-disk": "pd-balanced",
+                    "cloud.google.com/gke-container-runtime": "containerd",
+                    "cloud.google.com/gke-cpu-scaling-level": "32",
+                    "cloud.google.com/gke-gpu-driver-version": "latest",
+                    "cloud.google.com/gke-logging-variant": "DEFAULT",
+                    "cloud.google.com/gke-max-pods-per-node": "110",
+                    "cloud.google.com/gke-memory-gb-scaling-level": "122",
+                    "cloud.google.com/gke-nodepool": "default-pool",
+                    "cloud.google.com/gke-os-distribution": "cos",
+                    "cloud.google.com/gke-provisioning": "standard",
+                    "cloud.google.com/gke-stack-type": "IPV4",
+                    "cloud.google.com/machine-family": "n1",
+                    "cloud.google.com/private-node": "false",
+                    "failure-domain.beta.kubernetes.io/region": "us-central1",
+                    "failure-domain.beta.kubernetes.io/zone": "us-central1-a",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "gke-gpu-cluster-16-default-pool-4f4915d2-xg1n",
+                    "kubernetes.io/os": "linux",
+                    "node.kubernetes.io/instance-type": "n1-standard-32",
+                    "topology.gke.io/zone": "us-central1-a",
+                    "topology.kubernetes.io/region": "us-central1",
+                    "topology.kubernetes.io/zone": "us-central1-a"
+                },
+                "name": "gke-gpu-cluster-16-default-pool-4f4915d2-xg1n",
+                "resourceVersion": "3703",
+                "uid": "c048ce68-6acd-4606-84b9-851e1b74be42"
+            },
+            "spec": {
+                "podCIDR": "10.96.8.0/24",
+                "podCIDRs": [
+                    "10.96.8.0/24"
+                ],
+                "providerID": "gce://llnl-flux/us-central1-a/gke-gpu-cluster-16-default-pool-4f4915d2-xg1n"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "10.128.0.83",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "34.135.94.30",
+                        "type": "ExternalIP"
+                    },
+                    {
+                        "address": "gke-gpu-cluster-16-default-pool-4f4915d2-xg1n",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "15890m",
+                    "ephemeral-storage": "47060071478",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "114323360Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "16",
+                    "ephemeral-storage": "98831908Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "123654048Ki",
+                    "nvidia.com/gpu": "8",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:23:01Z",
+                        "lastTransitionTime": "2025-03-25T17:22:57Z",
+                        "message": "NodeController create implicit route",
+                        "reason": "RouteCreated",
+                        "status": "False",
+                        "type": "NetworkUnavailable"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'auths' field in containerd's config",
+                        "reason": "DeprecatedAuthsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedAuthsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "Filesystem is not read-only",
+                        "reason": "FilesystemIsNotReadOnly",
+                        "status": "False",
+                        "type": "ReadonlyFilesystem"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'mirrors' field in containerd's config",
+                        "reason": "DeprecatedMirrorsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedMirrorsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker is functioning properly",
+                        "reason": "NoFrequentDockerRestart",
+                        "status": "False",
+                        "type": "FrequentDockerRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecated 'configs' field in containerd's config",
+                        "reason": "DeprecatedConfigsFieldInContainerdConfigurationNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedConfigsFieldInContainerdConfiguration"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "{\"managed\": {\"net.core.somaxconn\": \"2048\", \"net.ipv4.tcp_rmem\": \"4096 87380 16777216\", \"net.ipv4.tcp_wmem\": \"4096 16384 16777216\"}}",
+                        "reason": "NodeSysctlChange",
+                        "status": "True",
+                        "type": "SysctlChanged"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not use v1alpha2 CRI",
+                        "reason": "DeprecatedUsingV1Alpha2CriNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedUsingV1Alpha2Cri"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "docker overlay2 is functioning properly",
+                        "reason": "NoCorruptDockerOverlay2",
+                        "status": "False",
+                        "type": "CorruptDockerOverlay2"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "node is functioning properly",
+                        "reason": "NoFrequentUnregisterNetDevice",
+                        "status": "False",
+                        "type": "FrequentUnregisterNetDevice"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "containerd is functioning properly",
+                        "reason": "NoFrequentContainerdRestart",
+                        "status": "False",
+                        "type": "FrequentContainerdRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not pull any schema v1 images",
+                        "reason": "DeprecatedPullingSchemaV1ImageDetected",
+                        "status": "False",
+                        "type": "DeprecatedPullingSchemaV1Image"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "No deprecation risk: did not find any deprecations other than 3 configs fields (auths/configs/mirrors), pulling schema v1 images and using v1alpha2 CRI.",
+                        "reason": "DeprecatedOtherContainerdFeaturesNotDetected",
+                        "status": "False",
+                        "type": "DeprecatedOtherContainerdFeatures"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kubelet is functioning properly",
+                        "reason": "NoFrequentKubeletRestart",
+                        "status": "False",
+                        "type": "FrequentKubeletRestart"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:21:55Z",
+                        "lastTransitionTime": "2025-03-25T17:20:51Z",
+                        "message": "kernel has no deadlock",
+                        "reason": "KernelHasNoDeadlock",
+                        "status": "False",
+                        "type": "KernelDeadlock"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:19Z",
+                        "lastTransitionTime": "2025-03-25T17:21:58Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:19Z",
+                        "lastTransitionTime": "2025-03-25T17:21:58Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:19Z",
+                        "lastTransitionTime": "2025-03-25T17:21:58Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2025-03-25T17:24:19Z",
+                        "lastTransitionTime": "2025-03-25T17:23:17Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/cos-nvidia-installer:fixed",
+                            "gcr.io/cos-cloud/cos-gpu-installer:fixed",
+                            "us.gcr.io/cos-cloud/cos-gpu-installer:v2.4.7"
+                        ],
+                        "sizeBytes": 260351487
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "gcr.io/gke-release-staging/cilium/cilium:v1.15.6-gke1.31-gke.11@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "asia.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c",
+                            "eu.gcr.io/gke-release-staging/cilium/cilium@sha256:942c67b6761a0a4728d4debf45117d4cf94edad106ab0fa31356298dbe32699c"
+                        ],
+                        "sizeBytes": 172858664
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/prometheus@sha256:12a1ea30e057e7793982cf3c6cbcc3a18f7aaffe060b0ba59fb2da5433a40fd2"
+                        ],
+                        "sizeBytes": 113373794
+                    },
+                    {
+                        "names": [
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "gke.gcr.io/kube-proxy-amd64:v1.31.6-gke.1020000",
+                            "k8s.gcr.io/kube-proxy-amd64:v1.31.6-gke.100",
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.31.6-gke.1020000"
+                        ],
+                        "sizeBytes": 95048888
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit@sha256:bd48755377a723a91bc3fd96f67796ba3a3023808fd69b37d97cb1aa5985d9ae"
+                        ],
+                        "sizeBytes": 93330926
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/operator@sha256:5025cbef7f91274c585dd87c45a068f6cf06c37cdb2f8c317b2f2c77ac00aa02"
+                        ],
+                        "sizeBytes": 84747190
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gcp-compute-persistent-disk-csi-driver@sha256:bbbf275b1482cf3fc658f0bde28b1fbd24054451b5a97e23812821c82374a2b2"
+                        ],
+                        "sizeBytes": 60814920
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-engine/config-reloader@sha256:c4a8f16a9daed4d61420b55d3c6e5c3c68301c7fc33e2ebd0673ac9fb7c6191d"
+                        ],
+                        "sizeBytes": 59977054
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gpu-maintenance-handler@sha256:8a85a94107f2141c363c88cd818fac9c56cefa627bff5c01e2f716908c7cc1af"
+                        ],
+                        "sizeBytes": 49007632
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "gcr.io/gke-release-staging/cilium/certgen:v0.1.13-gke.15@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "asia.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1",
+                            "eu.gcr.io/gke-release-staging/cilium/certgen@sha256:3af6f68b14508821ce5039d11b5ccc2a454a2a6f8123130a6b0051a722522ab1"
+                        ],
+                        "sizeBytes": 40760801
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/k8s-dns-dnsmasq-nanny@sha256:e178b753d49a90ec32f1f45e0f52ce64019641d3fd45d8deadcf08cb73b8c840"
+                        ],
+                        "sizeBytes": 37001839
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-to-sd@sha256:798127b7368b1a3a2851a6a336776739f32b0ed741d5d6ee07b97d6ac2998fa3"
+                        ],
+                        "sizeBytes": 35898621
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/prometheus-to-sd@sha256:45cf400724506f23ffac38b2034d6de4ab95b50f7b2dc2fa10f32f079076daba"
+                        ],
+                        "sizeBytes": 35898618
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent:v1.15.6-gke1.31-gke.11@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "asia.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037",
+                            "eu.gcr.io/gke-release-staging/cilium/slim-daemon/anet-agent@sha256:1a928db466182ca350f85f4c8fab946b429e04c9342d6cf02ccb25fe7cf80037"
+                        ],
+                        "sizeBytes": 34897038
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/fluent-bit-gke-exporter@sha256:c85045c80354c2ac7931a103cc3f9d16dd08682e87383be254b37543dfcf0279"
+                        ],
+                        "sizeBytes": 32900579
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/k8s-dns-kube-dns@sha256:b609a51c8aa4add2d1d0811737f177b4e944ea0781a48eead0d804722787f96f"
+                        ],
+                        "sizeBytes": 32667404
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/k8s-dns-sidecar@sha256:9e60f83b54d010a7dd7e5a868a6713ad410442c72f0b7540cda010c50651c0bc"
+                        ],
+                        "sizeBytes": 29112653
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/proxy-agent@sha256:abf95907d2fdbc47cf1629de14b4d44675e8fac76a8b52e2613b92cee231791e"
+                        ],
+                        "sizeBytes": 28969868
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-agent@sha256:919c4c4d46db4c8a0125eb2254d073c882c6b765a1d2c713e69bbe6b6c94cd86"
+                        ],
+                        "sizeBytes": 27456613
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:3d76420863be0cdbdf5f9a512e032d9b20ae8fd7be4b5eca22ecdb1e867f23bf"
+                        ],
+                        "sizeBytes": 25809971
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:f6800ad0fa4cb22cde9e185ccf0723a6b1cd237eeb33d4cbcd67e9a46779f91a"
+                        ],
+                        "sizeBytes": 25591702
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:9678041ad0020efc360d4a9c0c616b48cc1224599545a103be3b2b853c521914"
+                        ],
+                        "sizeBytes": 25588923
+                    },
+                    {
+                        "names": [
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "gcr.io/gke-release-staging/gke-metrics-collector:20241015_2300_RC0@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "asia.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016",
+                            "eu.gcr.io/gke-release-staging/gke-metrics-collector@sha256:1c838e782e8825f4c635ffa212833558976f16af700fbf4fcd9cf6103350d016"
+                        ],
+                        "sizeBytes": 24951828
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:52df59dabb65d3d315ee03768ca1e9d84da2821a799c54cab7539f5f5b19849e"
+                        ],
+                        "sizeBytes": 24781314
+                    },
+                    {
+                        "names": [
+                            "us-central1-artifactregistry.gcr.io/gke-release/gke-release/gke-metrics-collector@sha256:d460e6b5088332f62b990f8a1f7bf6d9eca7c3f41cb974e3db493d6b0fc4ad70"
+                        ],
+                        "sizeBytes": 24425624
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "036248c0-7586-4862-9426-871dad274c73",
+                    "containerRuntimeVersion": "containerd://1.7.24",
+                    "kernelVersion": "6.6.72+",
+                    "kubeProxyVersion": "v1.31.6-gke.1020000",
+                    "kubeletVersion": "v1.31.6-gke.1020000",
+                    "machineID": "78447827acc1456e46f46443ab023618",
+                    "operatingSystem": "linux",
+                    "osImage": "Container-Optimized OS from Google",
+                    "systemUUID": "78447827-acc1-456e-46f4-6443ab023618"
+                }
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-0-654193983488.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-0-654193983488.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      27.83
+1                      28.13
+2                      28.17
+4                      28.53
+8                      28.19
+16                     27.80
+32                     28.35
+64                     31.28
+128                    30.64
+256                    31.97
+512                    31.44
+1024                   32.31
+2048                   33.73
+4096                   36.60
+8192                   42.27
+16384                  48.15
+32768                  70.18
+65536                 147.22
+131072                169.30
+262144                218.01
+524288                298.49
+1048576               461.93
+2097152               790.29
+4194304              1459.66
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-14"]}}, "user": {"study_id": "osu-2-iter-0"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923834.9710662,"name":"init"}
+{"timestamp":1742923834.9719613,"name":"starting"}
+{"timestamp":1742923835.0039864,"name":"shell.init","context":{"service":"0-shell-fJBhtAWs","leader-rank":7,"size":2}}
+{"timestamp":1742923835.0118561,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923853.2347238,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":104,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923853.2430079,"name":"complete","context":{"status":0}}
+{"timestamp":1742923853.2430429,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-0-965730107392.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-0-965730107392.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.13
+2                       0.26
+4                       0.51
+8                       1.02
+16                      2.04
+32                      4.04
+64                      7.94
+128                    15.88
+256                    31.66
+512                    62.83
+1024                  126.39
+2048                  248.13
+4096                  473.68
+8192                  867.03
+16384                1477.55
+32768                1985.51
+65536                1697.52
+131072               2460.25
+262144               2798.77
+524288               2971.03
+1048576              3237.89
+2097152              3305.51
+4194304              3291.05
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-14"]}}, "user": {"study_id": "osu-2-iter-0"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923853.5402427,"name":"init"}
+{"timestamp":1742923853.541203,"name":"starting"}
+{"timestamp":1742923853.5738132,"name":"shell.init","context":{"service":"0-shell-fSNMGEPy","leader-rank":7,"size":2}}
+{"timestamp":1742923853.5820827,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923859.3569193,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":107,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923859.365495,"name":"complete","context":{"status":0}}
+{"timestamp":1742923859.3655295,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-1-1068725436416.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-1-1068725436416.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      28.10
+1                      27.51
+2                      27.70
+4                      27.82
+8                      28.38
+16                     28.16
+32                     28.14
+64                     30.07
+128                    29.98
+256                    31.44
+512                    31.88
+1024                   32.36
+2048                   33.80
+4096                   36.46
+8192                   42.56
+16384                  50.22
+32768                  70.34
+65536                 147.28
+131072                167.99
+262144                223.51
+524288                299.64
+1048576               462.00
+2097152               792.13
+4194304              1460.64
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-6"]}}, "user": {"study_id": "osu-2-iter-1"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923859.6794116,"name":"init"}
+{"timestamp":1742923859.6803207,"name":"starting"}
+{"timestamp":1742923859.7067456,"name":"shell.init","context":{"service":"0-shell-fV5GcDQs","leader-rank":6,"size":2}}
+{"timestamp":1742923859.7136748,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923877.902442,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":104,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923877.9098649,"name":"complete","context":{"status":0}}
+{"timestamp":1742923877.909899,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-1-1379724689408.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-1-1379724689408.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.13
+2                       0.26
+4                       0.52
+8                       1.05
+16                      2.08
+32                      4.07
+64                      8.09
+128                    15.88
+256                    31.68
+512                    62.75
+1024                  125.12
+2048                  240.93
+4096                  449.66
+8192                  837.36
+16384                1463.08
+32768                2009.59
+65536                1623.80
+131072               2363.92
+262144               2768.55
+524288               2994.53
+1048576              3178.69
+2097152              3275.88
+4194304              3317.90
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-6"]}}, "user": {"study_id": "osu-2-iter-1"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923878.2171769,"name":"init"}
+{"timestamp":1742923878.2182255,"name":"starting"}
+{"timestamp":1742923878.2459853,"name":"shell.init","context":{"service":"0-shell-fdF6YgGw","leader-rank":6,"size":2}}
+{"timestamp":1742923878.2535877,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923884.0431166,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":107,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923884.050236,"name":"complete","context":{"status":0}}
+{"timestamp":1742923884.0502684,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-10-4768336445440.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-10-4768336445440.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      27.91
+1                      27.92
+2                      27.50
+4                      27.49
+8                      27.82
+16                     27.40
+32                     27.22
+64                     29.24
+128                    29.73
+256                    30.56
+512                    30.90
+1024                   31.30
+2048                   32.76
+4096                   35.57
+8192                   41.62
+16384                  48.33
+32768                  69.04
+65536                 143.86
+131072                164.49
+262144                220.35
+524288                288.74
+1048576               447.41
+2097152               772.46
+4194304              1417.61
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-5"]}}, "user": {"study_id": "osu-2-iter-10"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924080.1943266,"name":"init"}
+{"timestamp":1742924080.1954362,"name":"starting"}
+{"timestamp":1742924080.2230206,"name":"shell.init","context":{"service":"0-shell-f3AFrZftB","leader-rank":5,"size":2}}
+{"timestamp":1742924080.2298248,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924097.9244118,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":110,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924097.9305618,"name":"complete","context":{"status":0}}
+{"timestamp":1742924097.9305997,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-10-5070930313216.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-10-5070930313216.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.29
+4                       0.57
+8                       1.13
+16                      2.23
+32                      4.46
+64                      8.44
+128                    17.20
+256                    33.26
+512                    67.50
+1024                  125.59
+2048                  235.10
+4096                  461.31
+8192                  846.12
+16384                1510.72
+32768                1960.43
+65536                1820.70
+131072               2497.30
+262144               2907.01
+524288               3138.01
+1048576              3298.04
+2097152              3449.24
+4194304              3460.04
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-5"]}}, "user": {"study_id": "osu-2-iter-10"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924098.2306471,"name":"init"}
+{"timestamp":1742924098.2318048,"name":"starting"}
+{"timestamp":1742924098.2556491,"name":"shell.init","context":{"service":"0-shell-f3JCskLZV","leader-rank":5,"size":2}}
+{"timestamp":1742924098.262809,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924103.8374248,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":113,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924103.843477,"name":"complete","context":{"status":0}}
+{"timestamp":1742924103.8435185,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-11-5170217877504.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-11-5170217877504.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      25.92
+1                      27.59
+2                      25.98
+4                      26.08
+8                      25.91
+16                     26.28
+32                     26.11
+64                     27.74
+128                    28.06
+256                    29.41
+512                    29.20
+1024                   30.12
+2048                   31.54
+4096                   33.90
+8192                   40.66
+16384                  45.33
+32768                  65.18
+65536                 140.56
+131072                160.52
+262144                210.51
+524288                279.18
+1048576               432.53
+2097152               745.03
+4194304              1395.12
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-11"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924104.1480198,"name":"init"}
+{"timestamp":1742924104.1491456,"name":"starting"}
+{"timestamp":1742924104.1815062,"name":"shell.init","context":{"service":"0-shell-f3Lp9T4JB","leader-rank":12,"size":2}}
+{"timestamp":1742924104.1899283,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924121.2699347,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":110,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924121.2778833,"name":"complete","context":{"status":0}}
+{"timestamp":1742924121.2779274,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-11-5462594420736.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-11-5462594420736.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.15
+2                       0.29
+4                       0.59
+8                       1.19
+16                      2.35
+32                      4.68
+64                      9.10
+128                    18.48
+256                    36.53
+512                    72.28
+1024                  138.32
+2048                  273.17
+4096                  516.82
+8192                  936.36
+16384                1501.91
+32768                1931.52
+65536                1891.23
+131072               2616.85
+262144               3146.95
+524288               3237.57
+1048576              3498.85
+2097152              3569.28
+4194304              3497.23
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-11"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924121.5758948,"name":"init"}
+{"timestamp":1742924121.5771298,"name":"starting"}
+{"timestamp":1742924121.6094799,"name":"shell.init","context":{"service":"0-shell-f3UVbmGMV","leader-rank":12,"size":2}}
+{"timestamp":1742924121.6177402,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924127.0363491,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":113,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924127.044291,"name":"complete","context":{"status":0}}
+{"timestamp":1742924127.0443256,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-12-5559466065920.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-12-5559466065920.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      27.32
+1                      26.98
+2                      26.97
+4                      27.00
+8                      26.88
+16                     27.07
+32                     27.24
+64                     29.20
+128                    29.38
+256                    30.43
+512                    30.87
+1024                   31.47
+2048                   32.65
+4096                   38.35
+8192                   43.43
+16384                  50.02
+32768                  68.91
+65536                 151.95
+131072                167.82
+262144                220.07
+524288                293.13
+1048576               445.22
+2097152               772.62
+4194304              1442.57
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-12"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924127.3492386,"name":"init"}
+{"timestamp":1742924127.350353,"name":"starting"}
+{"timestamp":1742924127.3802745,"name":"shell.init","context":{"service":"0-shell-f3X3BymWX","leader-rank":4,"size":2}}
+{"timestamp":1742924127.388278,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924145.1693678,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":110,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924145.1776772,"name":"complete","context":{"status":0}}
+{"timestamp":1742924145.1777122,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-12-5863653769216.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-12-5863653769216.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.12
+2                       0.24
+4                       0.47
+8                       0.96
+16                      1.89
+32                      3.70
+64                      7.02
+128                    15.03
+256                    29.83
+512                    58.40
+1024                  119.53
+2048                  217.85
+4096                  410.70
+8192                  791.03
+16384                1338.04
+32768                2000.18
+65536                1512.00
+131072               2063.01
+262144               2498.33
+524288               2686.23
+1048576              2902.77
+2097152              2924.09
+4194304              2956.38
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-12"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924145.4802561,"name":"init"}
+{"timestamp":1742924145.4814913,"name":"starting"}
+{"timestamp":1742924145.50897,"name":"shell.init","context":{"service":"0-shell-f3f2e1Fxb","leader-rank":4,"size":2}}
+{"timestamp":1742924145.5160851,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924151.8011491,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":113,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924151.8083556,"name":"complete","context":{"status":0}}
+{"timestamp":1742924151.8083901,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-13-5974886711296.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-13-5974886711296.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      26.75
+1                      27.04
+2                      26.85
+4                      27.05
+8                      26.66
+16                     27.11
+32                     27.03
+64                     28.76
+128                    28.74
+256                    30.10
+512                    30.59
+1024                   30.30
+2048                   32.23
+4096                   34.92
+8192                   40.83
+16384                  47.75
+32768                  67.73
+65536                 140.65
+131072                161.67
+262144                215.89
+524288                291.77
+1048576               449.58
+2097152               772.00
+4194304              1429.15
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-6,flux-sample-13"]}}, "user": {"study_id": "osu-2-iter-13"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924152.1104078,"name":"init"}
+{"timestamp":1742924152.1115901,"name":"starting"}
+{"timestamp":1742924152.1395721,"name":"shell.init","context":{"service":"0-shell-f3hx7HALo","leader-rank":6,"size":2}}
+{"timestamp":1742924152.1470242,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924169.6444142,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":116,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924169.6493926,"name":"complete","context":{"status":0}}
+{"timestamp":1742924169.6494298,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-13-6274309685248.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-13-6274309685248.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.27
+4                       0.54
+8                       1.07
+16                      2.11
+32                      4.23
+64                      8.53
+128                    16.35
+256                    33.27
+512                    67.25
+1024                  128.68
+2048                  240.68
+4096                  470.64
+8192                  843.37
+16384                1414.23
+32768                2038.87
+65536                1744.19
+131072               2391.43
+262144               2807.67
+524288               3025.27
+1048576              3285.97
+2097152              3282.02
+4194304              3343.05
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-6,flux-sample-13"]}}, "user": {"study_id": "osu-2-iter-13"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924169.956882,"name":"init"}
+{"timestamp":1742924169.9583826,"name":"starting"}
+{"timestamp":1742924169.9843135,"name":"shell.init","context":{"service":"0-shell-f3qpJGAkw","leader-rank":6,"size":2}}
+{"timestamp":1742924169.9916289,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924175.6981945,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":119,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924175.7039194,"name":"complete","context":{"status":0}}
+{"timestamp":1742924175.7039549,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-14-6375946059776.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-14-6375946059776.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      27.21
+1                      27.23
+2                      27.62
+4                      27.01
+8                      27.39
+16                     27.41
+32                     26.97
+64                     28.90
+128                    29.60
+256                    30.36
+512                    30.76
+1024                   31.16
+2048                   33.01
+4096                   35.39
+8192                   41.62
+16384                  48.53
+32768                  69.31
+65536                 144.76
+131072                164.48
+262144                220.22
+524288                292.17
+1048576               453.07
+2097152               774.23
+4194304              1429.67
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-6,flux-sample-8"]}}, "user": {"study_id": "osu-2-iter-14"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924176.0153103,"name":"init"}
+{"timestamp":1742924176.0164392,"name":"starting"}
+{"timestamp":1742924176.0455656,"name":"shell.init","context":{"service":"0-shell-f3tV9X9wu","leader-rank":6,"size":2}}
+{"timestamp":1742924176.0529552,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924193.7333272,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":122,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924193.7408869,"name":"complete","context":{"status":0}}
+{"timestamp":1742924193.7409186,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-14-6678456041472.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-14-6678456041472.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.13
+2                       0.26
+4                       0.53
+8                       1.04
+16                      2.11
+32                      4.20
+64                      8.22
+128                    16.20
+256                    33.57
+512                    63.78
+1024                  130.45
+2048                  249.63
+4096                  441.35
+8192                  830.07
+16384                1460.14
+32768                1917.32
+65536                1856.38
+131072               2419.03
+262144               2820.15
+524288               3086.68
+1048576              3197.81
+2097152              3288.80
+4194304              3361.81
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-6,flux-sample-8"]}}, "user": {"study_id": "osu-2-iter-14"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924194.047811,"name":"init"}
+{"timestamp":1742924194.0490634,"name":"starting"}
+{"timestamp":1742924194.0789278,"name":"shell.init","context":{"service":"0-shell-f42S3HtDV","leader-rank":6,"size":2}}
+{"timestamp":1742924194.085623,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924199.8065953,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":125,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924199.8140023,"name":"complete","context":{"status":0}}
+{"timestamp":1742924199.8140364,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-15-6780360851456.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-15-6780360851456.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      27.70
+1                      27.63
+2                      27.59
+4                      27.49
+8                      27.60
+16                     27.65
+32                     27.90
+64                     29.48
+128                    29.81
+256                    31.26
+512                    31.47
+1024                   32.00
+2048                   33.50
+4096                   36.45
+8192                   42.53
+16384                  49.13
+32768                  70.86
+65536                 147.18
+131072                166.95
+262144                222.10
+524288                302.29
+1048576               462.04
+2097152               799.46
+4194304              1538.78
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-6,flux-sample-5"]}}, "user": {"study_id": "osu-2-iter-15"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924200.1205771,"name":"init"}
+{"timestamp":1742924200.121732,"name":"starting"}
+{"timestamp":1742924200.1498761,"name":"shell.init","context":{"service":"0-shell-f457JGfuy","leader-rank":5,"size":2}}
+{"timestamp":1742924200.1568458,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924218.3298202,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":116,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924218.3354988,"name":"complete","context":{"status":0}}
+{"timestamp":1742924218.3355365,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-15-7091024560128.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-15-7091024560128.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.12
+2                       0.25
+4                       0.50
+8                       1.03
+16                      2.05
+32                      4.03
+64                      8.04
+128                    16.08
+256                    32.04
+512                    63.75
+1024                  121.41
+2048                  234.63
+4096                  444.03
+8192                  805.50
+16384                1368.80
+32768                1986.01
+65536                1645.91
+131072               2289.31
+262144               2705.11
+524288               2935.66
+1048576              3152.82
+2097152              3245.73
+4194304              3146.02
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-6,flux-sample-5"]}}, "user": {"study_id": "osu-2-iter-15"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924218.638248,"name":"init"}
+{"timestamp":1742924218.639535,"name":"starting"}
+{"timestamp":1742924218.6664782,"name":"shell.init","context":{"service":"0-shell-f4DGcZP99","leader-rank":5,"size":2}}
+{"timestamp":1742924218.6740551,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924224.5897324,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":119,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924224.5953593,"name":"complete","context":{"status":0}}
+{"timestamp":1742924224.5953915,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-16-7196200927232.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-16-7196200927232.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      26.74
+1                      26.90
+2                      26.72
+4                      27.39
+8                      27.56
+16                     27.08
+32                     26.79
+64                     28.49
+128                    28.94
+256                    29.78
+512                    30.01
+1024                   30.33
+2048                   31.63
+4096                   34.69
+8192                   40.89
+16384                  47.01
+32768                  66.04
+65536                 137.10
+131072                157.81
+262144                217.32
+524288                288.12
+1048576               435.88
+2097152               761.98
+4194304              1382.02
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-6,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-16"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924224.9062488,"name":"init"}
+{"timestamp":1742924224.907418,"name":"starting"}
+{"timestamp":1742924224.934607,"name":"shell.init","context":{"service":"0-shell-f4G2rdkns","leader-rank":6,"size":2}}
+{"timestamp":1742924224.9415138,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924242.2543669,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":134,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924242.2605255,"name":"complete","context":{"status":0}}
+{"timestamp":1742924242.2605557,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-16-7492453007360.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-16-7492453007360.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.13
+2                       0.26
+4                       0.52
+8                       1.04
+16                      2.12
+32                      4.36
+64                      8.55
+128                    16.66
+256                    33.48
+512                    64.87
+1024                  124.74
+2048                  242.70
+4096                  449.97
+8192                  831.89
+16384                1453.76
+32768                1808.70
+65536                1827.51
+131072               2386.09
+262144               2842.67
+524288               2956.02
+1048576              3363.93
+2097152              3264.52
+4194304              3364.74
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-6,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-16"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924242.5649617,"name":"init"}
+{"timestamp":1742924242.5662963,"name":"starting"}
+{"timestamp":1742924242.5936942,"name":"shell.init","context":{"service":"0-shell-f4PpDR6wq","leader-rank":6,"size":2}}
+{"timestamp":1742924242.6005886,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924248.3126118,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":137,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924248.3186595,"name":"complete","context":{"status":0}}
+{"timestamp":1742924248.3186934,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-17-7594106159104.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-17-7594106159104.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      25.50
+1                      25.59
+2                      25.55
+4                      25.95
+8                      26.16
+16                     25.84
+32                     26.28
+64                     27.85
+128                    27.89
+256                    29.17
+512                    29.07
+1024                   29.67
+2048                   31.67
+4096                   34.00
+8192                   39.34
+16384                  44.84
+32768                  65.82
+65536                 137.91
+131072                157.80
+262144                206.49
+524288                284.88
+1048576               437.73
+2097152               770.32
+4194304              1422.53
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-6,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-17"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924248.6230471,"name":"init"}
+{"timestamp":1742924248.6242094,"name":"starting"}
+{"timestamp":1742924248.6511676,"name":"shell.init","context":{"service":"0-shell-f4SV6A5R9","leader-rank":4,"size":2}}
+{"timestamp":1742924248.6595109,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924265.7492645,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":116,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924265.7567143,"name":"complete","context":{"status":0}}
+{"timestamp":1742924265.756748,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-17-7886767915008.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-17-7886767915008.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.28
+4                       0.54
+8                       1.05
+16                      2.05
+32                      4.38
+64                      8.73
+128                    17.29
+256                    34.04
+512                    65.65
+1024                  129.63
+2048                  249.95
+4096                  472.10
+8192                  866.71
+16384                1386.94
+32768                1965.55
+65536                1945.14
+131072               2516.78
+262144               2780.87
+524288               3116.07
+1048576              3217.46
+2097152              3400.48
+4194304              3414.06
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-6,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-17"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924266.0680065,"name":"init"}
+{"timestamp":1742924266.0693467,"name":"starting"}
+{"timestamp":1742924266.096328,"name":"shell.init","context":{"service":"0-shell-f4aAyg5GK","leader-rank":4,"size":2}}
+{"timestamp":1742924266.1035123,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924271.7458503,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":119,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924271.7530138,"name":"complete","context":{"status":0}}
+{"timestamp":1742924271.7530482,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-18-7987280216064.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-18-7987280216064.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      27.07
+1                      26.69
+2                      26.86
+4                      27.81
+8                      27.42
+16                     26.49
+32                     26.63
+64                     28.70
+128                    29.29
+256                    29.93
+512                    30.35
+1024                   30.09
+2048                   31.80
+4096                   34.69
+8192                   40.78
+16384                  49.21
+32768                  66.93
+65536                 138.75
+131072                162.25
+262144                216.44
+524288                289.72
+1048576               444.87
+2097152               767.17
+4194304              1418.10
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-13,flux-sample-8"]}}, "user": {"study_id": "osu-2-iter-18"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924272.0583167,"name":"init"}
+{"timestamp":1742924272.0596304,"name":"starting"}
+{"timestamp":1742924272.0990827,"name":"shell.init","context":{"service":"0-shell-f4cp7btaB","leader-rank":8,"size":2}}
+{"timestamp":1742924272.1088994,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924289.5578756,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":122,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924289.5670214,"name":"complete","context":{"status":0}}
+{"timestamp":1742924289.56706,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-18-8286149541888.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-18-8286149541888.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.27
+4                       0.53
+8                       1.04
+16                      2.04
+32                      4.26
+64                      8.35
+128                    16.99
+256                    33.82
+512                    66.26
+1024                  134.40
+2048                  245.66
+4096                  456.04
+8192                  868.90
+16384                1491.79
+32768                2020.34
+65536                1740.29
+131072               2352.93
+262144               2831.07
+524288               3036.36
+1048576              3263.73
+2097152              3325.42
+4194304              3341.37
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-13,flux-sample-8"]}}, "user": {"study_id": "osu-2-iter-18"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924289.8728986,"name":"init"}
+{"timestamp":1742924289.8742704,"name":"starting"}
+{"timestamp":1742924289.9072967,"name":"shell.init","context":{"service":"0-shell-f4kfTfJgw","leader-rank":8,"size":2}}
+{"timestamp":1742924289.9155602,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924295.622792,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":125,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924295.6315982,"name":"complete","context":{"status":0}}
+{"timestamp":1742924295.6316473,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-19-8387869802496.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-19-8387869802496.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      29.61
+1                      31.16
+2                      28.19
+4                      29.88
+8                      27.17
+16                     28.21
+32                     30.09
+64                     35.70
+128                    29.14
+256                    32.92
+512                    30.26
+1024                   31.02
+2048                   32.71
+4096                   35.35
+8192                   41.32
+16384                  47.43
+32768                  68.60
+65536                 143.96
+131072                166.62
+262144                237.79
+524288                320.06
+1048576               467.37
+2097152               812.31
+4194304              1461.25
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-13,flux-sample-5"]}}, "user": {"study_id": "osu-2-iter-19"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924295.9363894,"name":"init"}
+{"timestamp":1742924295.9376669,"name":"starting"}
+{"timestamp":1742924295.9676282,"name":"shell.init","context":{"service":"0-shell-f4oLSLEHd","leader-rank":5,"size":2}}
+{"timestamp":1742924295.9751954,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924314.342334,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":122,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924314.3492098,"name":"complete","context":{"status":0}}
+{"timestamp":1742924314.3492439,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-19-8701956063232.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-19-8701956063232.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.13
+2                       0.26
+4                       0.51
+8                       1.04
+16                      2.09
+32                      4.09
+64                      8.09
+128                    15.72
+256                    31.53
+512                    62.74
+1024                  122.01
+2048                  233.26
+4096                  428.08
+8192                  770.37
+16384                1269.33
+32768                1847.99
+65536                1622.20
+131072               2140.92
+262144               2705.24
+524288               2833.71
+1048576              3115.14
+2097152              3163.12
+4194304              3182.18
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-13,flux-sample-5"]}}, "user": {"study_id": "osu-2-iter-19"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924314.6564231,"name":"init"}
+{"timestamp":1742924314.6578431,"name":"starting"}
+{"timestamp":1742924314.6858399,"name":"shell.init","context":{"service":"0-shell-f4way4R19","leader-rank":5,"size":2}}
+{"timestamp":1742924314.6942217,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924320.638993,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":125,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924320.6471779,"name":"complete","context":{"status":0}}
+{"timestamp":1742924320.6472127,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-2-1482636132352.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-2-1482636132352.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      26.91
+1                      26.63
+2                      26.79
+4                      26.44
+8                      26.51
+16                     27.19
+32                     26.87
+64                     28.61
+128                    28.65
+256                    29.65
+512                    29.96
+1024                   30.28
+2048                   31.78
+4096                   35.10
+8192                   41.08
+16384                  48.94
+32768                  66.46
+65536                 139.10
+131072                167.98
+262144                226.52
+524288                312.59
+1048576               516.90
+2097152               914.47
+4194304              1676.25
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-13"]}}, "user": {"study_id": "osu-2-iter-2"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923884.3508005,"name":"init"}
+{"timestamp":1742923884.3516884,"name":"starting"}
+{"timestamp":1742923884.3843074,"name":"shell.init","context":{"service":"0-shell-ffwtUit7","leader-rank":7,"size":2}}
+{"timestamp":1742923884.3927486,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923902.9302723,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":116,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923902.9389169,"name":"complete","context":{"status":0}}
+{"timestamp":1742923902.9389522,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-2-1799540965376.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-2-1799540965376.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.28
+4                       0.55
+8                       1.04
+16                      2.12
+32                      4.33
+64                      8.33
+128                    16.73
+256                    33.46
+512                    65.55
+1024                  128.66
+2048                  253.84
+4096                  457.48
+8192                  823.09
+16384                1406.24
+32768                1447.91
+65536                1710.27
+131072               2393.10
+262144               2952.85
+524288               3140.74
+1048576              3291.13
+2097152              3343.42
+4194304              3390.37
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-13"]}}, "user": {"study_id": "osu-2-iter-2"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923903.2395518,"name":"init"}
+{"timestamp":1742923903.2405341,"name":"starting"}
+{"timestamp":1742923903.2734935,"name":"shell.init","context":{"service":"0-shell-fpGiGpwZ","leader-rank":7,"size":2}}
+{"timestamp":1742923903.2806685,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923908.951844,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":119,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923908.9607985,"name":"complete","context":{"status":0}}
+{"timestamp":1742923908.9608324,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-20-8807635746816.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-20-8807635746816.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      26.18
+1                      25.61
+2                      25.93
+4                      25.64
+8                      25.70
+16                     25.85
+32                     25.67
+64                     27.26
+128                    27.84
+256                    28.81
+512                    29.25
+1024                   30.04
+2048                   31.41
+4096                   33.92
+8192                   40.97
+16384                  52.51
+32768                  65.42
+65536                 135.19
+131072                152.17
+262144                207.86
+524288                276.36
+1048576               431.04
+2097152               743.59
+4194304              1373.57
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-13,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-20"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924320.9557505,"name":"init"}
+{"timestamp":1742924320.9570148,"name":"starting"}
+{"timestamp":1742924320.9899237,"name":"shell.init","context":{"service":"0-shell-f4zMycR7D","leader-rank":12,"size":2}}
+{"timestamp":1742924320.9978871,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924337.913429,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":122,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924337.9211135,"name":"complete","context":{"status":0}}
+{"timestamp":1742924337.9211488,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-20-9097462153216.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-20-9097462153216.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.28
+4                       0.57
+8                       1.14
+16                      2.27
+32                      4.57
+64                      9.13
+128                    17.91
+256                    35.18
+512                    70.78
+1024                  139.37
+2048                  260.41
+4096                  482.87
+8192                  887.38
+16384                1470.04
+32768                1983.35
+65536                1880.95
+131072               2626.04
+262144               3063.86
+524288               3260.06
+1048576              3395.18
+2097152              3528.55
+4194304              3547.00
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-13,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-20"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924338.2309794,"name":"init"}
+{"timestamp":1742924338.2323205,"name":"starting"}
+{"timestamp":1742924338.2625608,"name":"shell.init","context":{"service":"0-shell-f57yYaWL7","leader-rank":12,"size":2}}
+{"timestamp":1742924338.2713668,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924343.7158985,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":125,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924343.7241826,"name":"complete","context":{"status":0}}
+{"timestamp":1742924343.724216,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-21-9194669342720.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-21-9194669342720.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      27.32
+1                      27.03
+2                      26.99
+4                      26.94
+8                      26.90
+16                     27.08
+32                     26.81
+64                     28.46
+128                    28.72
+256                    29.78
+512                    30.52
+1024                   30.73
+2048                   32.18
+4096                   34.96
+8192                   41.10
+16384                  48.56
+32768                  67.55
+65536                 139.09
+131072                161.36
+262144                215.91
+524288                291.95
+1048576               446.70
+2097152               763.01
+4194304              1399.96
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-13,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-21"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924344.0241828,"name":"init"}
+{"timestamp":1742924344.025378,"name":"starting"}
+{"timestamp":1742924344.0526795,"name":"shell.init","context":{"service":"0-shell-f5AXeSm83","leader-rank":4,"size":2}}
+{"timestamp":1742924344.0603316,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924361.48753,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":122,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924361.4958985,"name":"complete","context":{"status":0}}
+{"timestamp":1742924361.4959292,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-21-9492867579904.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-21-9492867579904.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.13
+2                       0.26
+4                       0.54
+8                       1.05
+16                      2.11
+32                      4.36
+64                      8.86
+128                    17.12
+256                    33.67
+512                    66.32
+1024                  132.20
+2048                  250.51
+4096                  460.43
+8192                  881.93
+16384                1474.08
+32768                2093.27
+65536                1781.02
+131072               2488.71
+262144               2790.24
+524288               3032.05
+1048576              3336.16
+2097152              3413.17
+4194304              3389.88
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-13,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-21"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924361.7997284,"name":"init"}
+{"timestamp":1742924361.8011272,"name":"starting"}
+{"timestamp":1742924361.8320267,"name":"shell.init","context":{"service":"0-shell-f5JMyCfy1","leader-rank":4,"size":2}}
+{"timestamp":1742924361.840215,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924367.4820387,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":125,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924367.491497,"name":"complete","context":{"status":0}}
+{"timestamp":1742924367.4915287,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-22-9593463767040.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-22-9593463767040.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      28.90
+1                      30.17
+2                      31.85
+4                      29.16
+8                      29.01
+16                     28.75
+32                     30.89
+64                     33.39
+128                    31.03
+256                    32.84
+512                    37.18
+1024                   32.66
+2048                   34.34
+4096                   39.38
+8192                   46.12
+16384                  51.76
+32768                  70.74
+65536                 149.37
+131072                174.30
+262144                226.12
+524288                307.35
+1048576               469.57
+2097152               827.92
+4194304              1543.34
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-8,flux-sample-5"]}}, "user": {"study_id": "osu-2-iter-22"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924367.7950816,"name":"init"}
+{"timestamp":1742924367.7964051,"name":"starting"}
+{"timestamp":1742924367.8273635,"name":"shell.init","context":{"service":"0-shell-f5M1EYRgb","leader-rank":5,"size":2}}
+{"timestamp":1742924367.8351774,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924386.8587277,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":128,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924386.8670967,"name":"complete","context":{"status":0}}
+{"timestamp":1742924386.8671315,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-22-9918522327040.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-22-9918522327040.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.12
+2                       0.24
+4                       0.49
+8                       0.92
+16                      1.87
+32                      3.97
+64                      7.83
+128                    15.71
+256                    31.33
+512                    63.75
+1024                  120.25
+2048                  234.78
+4096                  455.03
+8192                  848.92
+16384                1399.93
+32768                2061.61
+65536                1669.34
+131072               2311.72
+262144               2758.85
+524288               2982.08
+1048576              3142.45
+2097152              3231.56
+4194304              3207.78
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-8,flux-sample-5"]}}, "user": {"study_id": "osu-2-iter-22"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924387.1693921,"name":"init"}
+{"timestamp":1742924387.1708589,"name":"starting"}
+{"timestamp":1742924387.1999159,"name":"shell.init","context":{"service":"0-shell-f5VYUrWhd","leader-rank":5,"size":2}}
+{"timestamp":1742924387.2068527,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924393.1037545,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":131,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924393.1112263,"name":"complete","context":{"status":0}}
+{"timestamp":1742924393.1112621,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-23-10023329595392.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-23-10023329595392.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      26.52
+1                      26.61
+2                      26.98
+4                      26.64
+8                      26.93
+16                     26.75
+32                     26.88
+64                     28.52
+128                    28.87
+256                    29.74
+512                    29.97
+1024                   30.68
+2048                   32.04
+4096                   35.58
+8192                   40.54
+16384                  47.12
+32768                  65.16
+65536                 138.65
+131072                158.79
+262144                214.96
+524288                284.36
+1048576               439.74
+2097152               749.80
+4194304              1369.07
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-8,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-23"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924393.4169896,"name":"init"}
+{"timestamp":1742924393.4182706,"name":"starting"}
+{"timestamp":1742924393.4541402,"name":"shell.init","context":{"service":"0-shell-f5YJAKA9m","leader-rank":8,"size":2}}
+{"timestamp":1742924393.4623113,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924410.7132349,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":134,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924410.7222068,"name":"complete","context":{"status":0}}
+{"timestamp":1742924410.7222433,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-23-10318793146368.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-23-10318793146368.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.13
+2                       0.26
+4                       0.55
+8                       1.12
+16                      2.16
+32                      4.37
+64                      8.69
+128                    16.45
+256                    35.65
+512                    66.14
+1024                  130.21
+2048                  253.93
+4096                  493.36
+8192                  891.53
+16384                1480.77
+32768                2100.93
+65536                1756.62
+131072               2463.50
+262144               2968.23
+524288               3054.42
+1048576              3251.04
+2097152              3368.71
+4194304              3322.59
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-8,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-23"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924411.0276959,"name":"init"}
+{"timestamp":1742924411.0291185,"name":"starting"}
+{"timestamp":1742924411.0685155,"name":"shell.init","context":{"service":"0-shell-f5g4KR64X","leader-rank":8,"size":2}}
+{"timestamp":1742924411.0773683,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924416.7506936,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":137,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924416.7590628,"name":"complete","context":{"status":0}}
+{"timestamp":1742924416.7590973,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-24-10420144308224.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-24-10420144308224.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      27.93
+1                      27.11
+2                      27.02
+4                      27.65
+8                      27.63
+16                     27.48
+32                     27.31
+64                     29.02
+128                    29.38
+256                    30.78
+512                    30.96
+1024                   31.31
+2048                   32.75
+4096                   35.37
+8192                   41.49
+16384                  48.47
+32768                  68.08
+65536                 143.87
+131072                165.19
+262144                224.63
+524288                298.84
+1048576               455.45
+2097152               784.95
+4194304              1435.89
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-8,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-24"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924417.068177,"name":"init"}
+{"timestamp":1742924417.0694537,"name":"starting"}
+{"timestamp":1742924417.0965972,"name":"shell.init","context":{"service":"0-shell-f5iijUHTd","leader-rank":4,"size":2}}
+{"timestamp":1742924417.104208,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924434.8681312,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":128,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924434.8750443,"name":"complete","context":{"status":0}}
+{"timestamp":1742924434.8750803,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-24-10724030021632.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-24-10724030021632.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.27
+4                       0.57
+8                       1.12
+16                      2.26
+32                      4.46
+64                      8.83
+128                    17.32
+256                    34.83
+512                    63.25
+1024                  126.73
+2048                  245.50
+4096                  446.14
+8192                  906.21
+16384                1547.56
+32768                1970.01
+65536                1936.24
+131072               2517.25
+262144               2951.86
+524288               3117.34
+1048576              3309.58
+2097152              3386.36
+4194304              3362.93
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-8,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-24"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924435.1814566,"name":"init"}
+{"timestamp":1742924435.1829028,"name":"starting"}
+{"timestamp":1742924435.211463,"name":"shell.init","context":{"service":"0-shell-f5rhiozqV","leader-rank":4,"size":2}}
+{"timestamp":1742924435.2192531,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924440.8520546,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":131,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924440.858664,"name":"complete","context":{"status":0}}
+{"timestamp":1742924440.8587003,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-25-10824458436608.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-25-10824458436608.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      26.77
+1                      26.70
+2                      26.59
+4                      26.69
+8                      26.86
+16                     27.02
+32                     26.89
+64                     28.59
+128                    29.07
+256                    29.84
+512                    30.16
+1024                   30.69
+2048                   32.05
+4096                   34.94
+8192                   41.44
+16384                  49.25
+32768                  67.11
+65536                 142.07
+131072                162.34
+262144                220.79
+524288                309.77
+1048576               494.39
+2097152               859.60
+4194304              1607.02
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-5,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-25"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924441.1677697,"name":"init"}
+{"timestamp":1742924441.1690609,"name":"starting"}
+{"timestamp":1742924441.1973763,"name":"shell.init","context":{"service":"0-shell-f5uLjKsjd","leader-rank":5,"size":2}}
+{"timestamp":1742924441.2053792,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924459.367182,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":134,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924459.3728693,"name":"complete","context":{"status":0}}
+{"timestamp":1742924459.3729043,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-25-11135071813632.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-25-11135071813632.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.13
+2                       0.25
+4                       0.50
+8                       1.02
+16                      2.07
+32                      4.14
+64                      8.03
+128                    16.52
+256                    33.01
+512                    64.78
+1024                  127.57
+2048                  245.11
+4096                  461.17
+8192                  837.26
+16384                1422.89
+32768                2010.51
+65536                1723.74
+131072               2280.84
+262144               2880.11
+524288               3031.07
+1048576              3249.29
+2097152              3285.35
+4194304              3313.85
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-5,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-25"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924459.6828456,"name":"init"}
+{"timestamp":1742924459.6843734,"name":"starting"}
+{"timestamp":1742924459.7161436,"name":"shell.init","context":{"service":"0-shell-f63VyAd7m","leader-rank":5,"size":2}}
+{"timestamp":1742924459.7241795,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924465.4816184,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":137,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924465.4873626,"name":"complete","context":{"status":0}}
+{"timestamp":1742924465.4873986,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-26-11237597380608.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-26-11237597380608.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      28.15
+1                      27.74
+2                      27.95
+4                      28.25
+8                      27.67
+16                     28.08
+32                     27.65
+64                     29.54
+128                    29.91
+256                    31.66
+512                    31.80
+1024                   32.57
+2048                   33.80
+4096                   36.80
+8192                   42.90
+16384                  49.49
+32768                  69.62
+65536                 147.46
+131072                167.84
+262144                220.45
+524288                298.81
+1048576               460.99
+2097152               793.94
+4194304              1455.84
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-5,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-26"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924465.7935762,"name":"init"}
+{"timestamp":1742924465.7948859,"name":"starting"}
+{"timestamp":1742924465.8235185,"name":"shell.init","context":{"service":"0-shell-f66CAzxF1","leader-rank":4,"size":2}}
+{"timestamp":1742924465.8316436,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924483.9073422,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":134,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924483.914978,"name":"complete","context":{"status":0}}
+{"timestamp":1742924483.9150138,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-26-11546717585408.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-26-11546717585408.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.27
+4                       0.56
+8                       1.06
+16                      2.18
+32                      4.34
+64                      8.73
+128                    17.66
+256                    34.29
+512                    68.37
+1024                  132.82
+2048                  259.76
+4096                  452.97
+8192                  877.54
+16384                1495.84
+32768                1940.66
+65536                1717.60
+131072               2378.03
+262144               2870.23
+524288               3064.11
+1048576              3211.09
+2097152              3367.43
+4194304              3381.19
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-5,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-26"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924484.2179389,"name":"init"}
+{"timestamp":1742924484.2195668,"name":"starting"}
+{"timestamp":1742924484.2469857,"name":"shell.init","context":{"service":"0-shell-f6EK8toYT","leader-rank":4,"size":2}}
+{"timestamp":1742924484.2550917,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924489.9136159,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":137,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924489.922255,"name":"complete","context":{"status":0}}
+{"timestamp":1742924489.9222913,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-27-11647632539648.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-27-11647632539648.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      25.98
+1                      26.21
+2                      26.02
+4                      26.44
+8                      26.31
+16                     26.21
+32                     26.24
+64                     27.97
+128                    28.91
+256                    29.58
+512                    29.40
+1024                   29.66
+2048                   31.05
+4096                   34.08
+8192                   39.61
+16384                  47.68
+32768                  64.19
+65536                 135.11
+131072                158.36
+262144                215.43
+524288                306.42
+1048576               501.66
+2097152               890.02
+4194304              1745.40
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-12,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-27"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924490.2331498,"name":"init"}
+{"timestamp":1742924490.2346749,"name":"starting"}
+{"timestamp":1742924490.2626891,"name":"shell.init","context":{"service":"0-shell-f6GxtQKcb","leader-rank":4,"size":2}}
+{"timestamp":1742924490.2701361,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924508.5288494,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":140,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924508.5361414,"name":"complete","context":{"status":0}}
+{"timestamp":1742924508.5361767,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-27-11959822974976.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-27-11959822974976.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.12
+2                       0.27
+4                       0.55
+8                       1.11
+16                      2.15
+32                      4.39
+64                      8.72
+128                    17.00
+256                    32.55
+512                    67.07
+1024                  130.82
+2048                  258.25
+4096                  470.31
+8192                  859.98
+16384                1522.96
+32768                2065.47
+65536                1782.90
+131072               2451.26
+262144               2854.17
+524288               3156.04
+1048576              3326.99
+2097152              3434.85
+4194304              3432.71
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-12,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-27"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924508.8416378,"name":"init"}
+{"timestamp":1742924508.8432231,"name":"starting"}
+{"timestamp":1742924508.8724062,"name":"shell.init","context":{"service":"0-shell-f6RAXbuV9","leader-rank":4,"size":2}}
+{"timestamp":1742924508.8804305,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924514.4760394,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":143,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924514.4838016,"name":"complete","context":{"status":0}}
+{"timestamp":1742924514.4838357,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-3-1900556582912.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-3-1900556582912.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      27.57
+1                      27.79
+2                      27.01
+4                      27.20
+8                      26.97
+16                     27.23
+32                     27.23
+64                     28.99
+128                    29.40
+256                    30.38
+512                    30.81
+1024                   32.30
+2048                   33.50
+4096                   35.74
+8192                   41.69
+16384                  49.08
+32768                  69.98
+65536                 145.72
+131072                165.92
+262144                220.33
+524288                297.32
+1048576               463.56
+2097152               796.97
+4194304              1451.38
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-8"]}}, "user": {"study_id": "osu-2-iter-3"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923909.2602201,"name":"init"}
+{"timestamp":1742923909.2611179,"name":"starting"}
+{"timestamp":1742923909.2913721,"name":"shell.init","context":{"service":"0-shell-frvcgGhm","leader-rank":7,"size":2}}
+{"timestamp":1742923909.2988667,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923927.235703,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":122,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923927.2427299,"name":"complete","context":{"status":0}}
+{"timestamp":1742923927.2427659,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-3-2207378309120.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-3-2207378309120.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.12
+2                       0.26
+4                       0.51
+8                       1.01
+16                      2.01
+32                      4.05
+64                      8.25
+128                    15.80
+256                    32.03
+512                    63.32
+1024                  124.53
+2048                  245.85
+4096                  445.90
+8192                  838.37
+16384                1446.27
+32768                1954.69
+65536                1691.28
+131072               2404.41
+262144               2852.74
+524288               2993.39
+1048576              3197.62
+2097152              3315.96
+4194304              3371.18
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-8"]}}, "user": {"study_id": "osu-2-iter-3"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923927.5485857,"name":"init"}
+{"timestamp":1742923927.5496023,"name":"starting"}
+{"timestamp":1742923927.5819509,"name":"shell.init","context":{"service":"0-shell-fzz5TpPy","leader-rank":7,"size":2}}
+{"timestamp":1742923927.5901835,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923933.3250673,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":125,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923933.331629,"name":"complete","context":{"status":0}}
+{"timestamp":1742923933.3316653,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-4-2309450891264.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-4-2309450891264.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      29.82
+1                      30.12
+2                      30.14
+4                      29.95
+8                      29.90
+16                     29.87
+32                     29.94
+64                     31.57
+128                    31.69
+256                    32.72
+512                    33.68
+1024                   34.26
+2048                   35.70
+4096                   38.39
+8192                   45.12
+16384                  50.23
+32768                  71.78
+65536                 153.01
+131072                177.48
+262144                235.68
+524288                307.90
+1048576               468.83
+2097152               797.63
+4194304              1473.03
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-5"]}}, "user": {"study_id": "osu-2-iter-4"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923933.6324742,"name":"init"}
+{"timestamp":1742923933.6333702,"name":"starting"}
+{"timestamp":1742923933.6635156,"name":"shell.init","context":{"service":"0-shell-f23fbGUuu","leader-rank":5,"size":2}}
+{"timestamp":1742923933.6710503,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923952.5811579,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":104,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923952.5891099,"name":"complete","context":{"status":0}}
+{"timestamp":1742923952.5891404,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-4-2632546516992.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-4-2632546516992.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.12
+2                       0.25
+4                       0.51
+8                       1.01
+16                      2.05
+32                      4.08
+64                      8.18
+128                    16.09
+256                    31.55
+512                    62.86
+1024                  122.71
+2048                  236.75
+4096                  450.33
+8192                  814.18
+16384                1393.52
+32768                1915.62
+65536                1783.38
+131072               2399.29
+262144               2853.05
+524288               3004.68
+1048576              3230.24
+2097152              3316.12
+4194304              3342.10
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-5"]}}, "user": {"study_id": "osu-2-iter-4"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923952.8901176,"name":"init"}
+{"timestamp":1742923952.8911841,"name":"starting"}
+{"timestamp":1742923952.91852,"name":"shell.init","context":{"service":"0-shell-f2C9r81xb","leader-rank":5,"size":2}}
+{"timestamp":1742923952.9260685,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923958.6871238,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":107,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923958.6948199,"name":"complete","context":{"status":0}}
+{"timestamp":1742923958.6948512,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-5-2735055306752.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-5-2735055306752.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      26.86
+1                      26.88
+2                      26.77
+4                      26.81
+8                      26.59
+16                     26.56
+32                     26.48
+64                     28.33
+128                    28.52
+256                    29.71
+512                    29.89
+1024                   30.69
+2048                   32.08
+4096                   34.62
+8192                   40.84
+16384                  45.81
+32768                  66.03
+65536                 137.77
+131072                159.79
+262144                214.72
+524288                284.15
+1048576               439.92
+2097152               758.24
+4194304              1388.24
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-5"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923959.001128,"name":"init"}
+{"timestamp":1742923959.0021067,"name":"starting"}
+{"timestamp":1742923959.036237,"name":"shell.init","context":{"service":"0-shell-f2Er2UMoV","leader-rank":7,"size":2}}
+{"timestamp":1742923959.0447505,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923976.4022231,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":134,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923976.411494,"name":"complete","context":{"status":0}}
+{"timestamp":1742923976.4115283,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-5-3032246910976.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-5-3032246910976.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.26
+4                       0.54
+8                       1.09
+16                      2.17
+32                      4.40
+64                      8.43
+128                    16.88
+256                    33.31
+512                    65.61
+1024                  129.59
+2048                  254.01
+4096                  448.11
+8192                  853.57
+16384                1497.76
+32768                2053.87
+65536                1802.31
+131072               2446.85
+262144               2864.93
+524288               3046.25
+1048576              3264.37
+2097152              3363.64
+4194304              3395.42
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-12"]}}, "user": {"study_id": "osu-2-iter-5"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923976.7146962,"name":"init"}
+{"timestamp":1742923976.7157931,"name":"starting"}
+{"timestamp":1742923976.7525623,"name":"shell.init","context":{"service":"0-shell-f2NepH1jm","leader-rank":7,"size":2}}
+{"timestamp":1742923976.760865,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742923982.417022,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":137,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742923982.4265044,"name":"complete","context":{"status":0}}
+{"timestamp":1742923982.4265432,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-6-3133228974080.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-6-3133228974080.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      28.55
+1                      28.57
+2                      28.62
+4                      28.56
+8                      28.60
+16                     28.73
+32                     29.13
+64                     31.03
+128                    31.04
+256                    32.26
+512                    32.59
+1024                   33.06
+2048                   34.30
+4096                   37.75
+8192                   44.26
+16384                  49.19
+32768                  72.57
+65536                 151.04
+131072                172.42
+262144                226.18
+524288                303.11
+1048576               461.75
+2097152               783.34
+4194304              1439.49
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-6"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742923982.7336926,"name":"init"}
+{"timestamp":1742923982.7347047,"name":"starting"}
+{"timestamp":1742923982.7612262,"name":"shell.init","context":{"service":"0-shell-f2RJfiUwH","leader-rank":4,"size":2}}
+{"timestamp":1742923982.7680445,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924001.1761477,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":104,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924001.1826534,"name":"complete","context":{"status":0}}
+{"timestamp":1742924001.1826847,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-6-3447667556352.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-6-3447667556352.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.27
+4                       0.52
+8                       1.10
+16                      2.17
+32                      4.37
+64                      8.75
+128                    16.06
+256                    32.87
+512                    64.28
+1024                  123.87
+2048                  250.56
+4096                  463.92
+8192                  853.77
+16384                1509.87
+32768                1934.79
+65536                1838.52
+131072               2480.55
+262144               2755.63
+524288               3090.23
+1048576              3342.43
+2097152              3420.93
+4194304              3441.36
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-7,flux-sample-4"]}}, "user": {"study_id": "osu-2-iter-6"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924001.4765184,"name":"init"}
+{"timestamp":1742924001.4776845,"name":"starting"}
+{"timestamp":1742924001.5040159,"name":"shell.init","context":{"service":"0-shell-f2ZZjaQa3","leader-rank":4,"size":2}}
+{"timestamp":1742924001.5110304,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924007.1238961,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":107,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924007.1295104,"name":"complete","context":{"status":0}}
+{"timestamp":1742924007.1295488,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-7-3547710095360.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-7-3547710095360.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      27.37
+1                      27.73
+2                      27.10
+4                      27.06
+8                      27.19
+16                     27.52
+32                     27.43
+64                     29.25
+128                    30.11
+256                    30.77
+512                    30.52
+1024                   30.98
+2048                   32.29
+4096                   36.07
+8192                   41.55
+16384                  47.75
+32768                  67.52
+65536                 143.75
+131072                165.54
+262144                218.23
+524288                298.15
+1048576               456.38
+2097152               795.67
+4194304              1447.80
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-6"]}}, "user": {"study_id": "osu-2-iter-7"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924007.4386983,"name":"init"}
+{"timestamp":1742924007.4397621,"name":"starting"}
+{"timestamp":1742924007.467412,"name":"shell.init","context":{"service":"0-shell-f2cC9zZzF","leader-rank":6,"size":2}}
+{"timestamp":1742924007.4751956,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924025.2631395,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":110,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924025.267967,"name":"complete","context":{"status":0}}
+{"timestamp":1742924025.2680023,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-7-3851981684736.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-7-3851981684736.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.13
+2                       0.25
+4                       0.51
+8                       1.01
+16                      2.11
+32                      4.33
+64                      8.94
+128                    16.54
+256                    32.11
+512                    64.37
+1024                  132.71
+2048                  249.12
+4096                  453.83
+8192                  838.54
+16384                1437.21
+32768                2067.05
+65536                1833.59
+131072               2472.54
+262144               2978.78
+524288               3076.56
+1048576              3294.65
+2097152              3385.58
+4194304              3422.47
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-6"]}}, "user": {"study_id": "osu-2-iter-7"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924025.5742853,"name":"init"}
+{"timestamp":1742924025.575511,"name":"starting"}
+{"timestamp":1742924025.6012447,"name":"shell.init","context":{"service":"0-shell-f2kBjRzr3","leader-rank":6,"size":2}}
+{"timestamp":1742924025.6089175,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924031.2441583,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":113,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924031.2496326,"name":"complete","context":{"status":0}}
+{"timestamp":1742924031.2496662,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-8-3952175218688.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-8-3952175218688.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      26.57
+1                      26.39
+2                      26.44
+4                      26.52
+8                      26.29
+16                     26.08
+32                     26.47
+64                     28.06
+128                    28.86
+256                    29.50
+512                    30.12
+1024                   30.77
+2048                   31.60
+4096                   34.87
+8192                   40.91
+16384                  48.18
+32768                  66.82
+65536                 141.53
+131072                164.35
+262144                216.81
+524288                287.49
+1048576               445.15
+2097152               757.91
+4194304              1416.21
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-13"]}}, "user": {"study_id": "osu-2-iter-8"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924031.5467987,"name":"init"}
+{"timestamp":1742924031.5478504,"name":"starting"}
+{"timestamp":1742924031.5805607,"name":"shell.init","context":{"service":"0-shell-f2npPC3oM","leader-rank":13,"size":2}}
+{"timestamp":1742924031.5885084,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924048.9083374,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":110,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924048.9151697,"name":"complete","context":{"status":0}}
+{"timestamp":1742924048.9152057,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-8-4248813174784.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-8-4248813174784.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.14
+2                       0.27
+4                       0.54
+8                       1.10
+16                      2.20
+32                      4.49
+64                      8.98
+128                    18.14
+256                    35.63
+512                    70.47
+1024                  138.68
+2048                  268.89
+4096                  484.42
+8192                  859.62
+16384                1559.91
+32768                2021.21
+65536                1912.20
+131072               2524.70
+262144               2932.89
+524288               3106.25
+1048576              3391.42
+2097152              3445.54
+4194304              3417.40
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-13"]}}, "user": {"study_id": "osu-2-iter-8"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924049.2272589,"name":"init"}
+{"timestamp":1742924049.2284505,"name":"starting"}
+{"timestamp":1742924049.2617018,"name":"shell.init","context":{"service":"0-shell-f2vcL57SF","leader-rank":13,"size":2}}
+{"timestamp":1742924049.2698224,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924054.8297784,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":113,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924054.835799,"name":"complete","context":{"status":0}}
+{"timestamp":1742924054.8358357,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-9-4348184625152.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-9-4348184625152.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                      27.30
+1                      27.17
+2                      27.28
+4                      27.59
+8                      27.28
+16                     27.41
+32                     27.03
+64                     28.86
+128                    29.14
+256                    29.86
+512                    30.37
+1024                   31.17
+2048                   31.87
+4096                   35.13
+8192                   41.66
+16384                  50.03
+32768                  66.74
+65536                 138.46
+131072                166.76
+262144                225.74
+524288                318.60
+1048576               507.25
+2097152               896.52
+4194304              1732.97
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "gpu-affinity": "per-task", "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-8"]}}, "user": {"study_id": "osu-2-iter-9"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924055.150177,"name":"init"}
+{"timestamp":1742924055.1512024,"name":"starting"}
+{"timestamp":1742924055.1859329,"name":"shell.init","context":{"service":"0-shell-f2yDjBmaf","leader-rank":8,"size":2}}
+{"timestamp":1742924055.1934469,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924073.8470235,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":110,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924073.8566628,"name":"complete","context":{"status":0}}
+{"timestamp":1742924073.8567028,"name":"done"}
+

--- a/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-9-4667270496256.out
+++ b/experiments/google/gke/gpu/size16/results/osu-fixed/osu-2-iter-9-4667270496256.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       0.13
+2                       0.27
+4                       0.55
+8                       1.12
+16                      2.20
+32                      4.39
+64                      7.99
+128                    15.56
+256                    31.71
+512                    66.66
+1024                  137.51
+2048                  258.14
+4096                  474.14
+8192                  896.59
+16384                1557.97
+32768                1873.81
+65536                1870.52
+131072               2545.73
+262144               2772.12
+524288               3140.57
+1048576              3315.36
+2097152              3366.32
+4194304              3349.95
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-14,flux-sample-8"]}}, "user": {"study_id": "osu-2-iter-9"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1742924074.1694698,"name":"init"}
+{"timestamp":1742924074.1707687,"name":"starting"}
+{"timestamp":1742924074.203383,"name":"shell.init","context":{"service":"0-shell-f37bsiGGw","leader-rank":8,"size":2}}
+{"timestamp":1742924074.2114527,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1742924079.8719804,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":113,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1742924079.8811257,"name":"complete","context":{"status":0}}
+{"timestamp":1742924079.881161,"name":"done"}
+


### PR DESCRIPTION
We ran Google GPU setups with submit instead of run, meaning it was not blocking, and they likely ran at the same time and the result could be erroneous. Since we just need to run for pairs we are doing a re-run for the study paper size, 16 nodes or 128 GPU. We need to do the same for Azure.