### PR TITLE
osu re-runs - not a success

### DIFF
--- a/experiments/azure/aks/cpu/size256/results/osu-rerun/osu-2-iter-1-684644630528.out
+++ b/experiments/azure/aks/cpu/size256/results/osu-rerun/osu-2-iter-1-684644630528.out
@@ -1,0 +1,37 @@
+# OSU MPI Latency Test v5.8
+# Size          Latency (us)
+0                       1.59
+1                       1.58
+2                       1.58
+4                       1.58
+8                       1.59
+16                      1.59
+32                      1.74
+64                      1.79
+128                     1.85
+256                     2.35
+512                     2.47
+1024                    2.58
+2048                    2.75
+4096                    3.48
+8192                    4.09
+16384                   5.10
+32768                   6.59
+65536                   9.01
+131072                 13.22
+262144                 17.26
+524288                 27.81
+1048576                49.79
+2097152                92.36
+4194304               177.80
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_latency"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/azhpc-images/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-0,flux-sample-29"]}}, "user": {"study_id": "osu-2-iter-1"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1743294664.2062294,"name":"init"}
+{"timestamp":1743294664.2068343,"name":"starting"}
+{"timestamp":1743294664.2358925,"name":"shell.init","context":{"service":"0-shell-fJz6hgzj","leader-rank":0,"size":2}}
+{"timestamp":1743294664.2392285,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1743294666.3936222,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":366,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1743294666.4000165,"name":"complete","context":{"status":0}}
+{"timestamp":1743294666.4000454,"name":"done"}
+

--- a/experiments/azure/aks/cpu/size256/results/osu-rerun/osu-2-iter-1-723500662784.out
+++ b/experiments/azure/aks/cpu/size256/results/osu-rerun/osu-2-iter-1-723500662784.out
@@ -1,0 +1,36 @@
+# OSU MPI Bandwidth Test v5.8
+# Size      Bandwidth (MB/s)
+1                       3.85
+2                       7.87
+4                      15.51
+8                      31.56
+16                     62.61
+32                    121.06
+64                    243.40
+128                   488.32
+256                   925.33
+512                  1724.95
+1024                 3260.50
+2048                 5980.09
+4096                 9182.91
+8192                13711.41
+16384               18938.37
+32768               21164.41
+65536               22852.02
+131072              23628.27
+262144              24008.90
+524288              24114.70
+1048576             24228.32
+2097152             24397.00
+4194304             24486.00
+START OF JOBSPEC
+{"resources": [{"type": "node", "count": 2, "with": [{"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}], "label": "task"}]}], "tasks": [{"command": ["/opt/osu-benchmark/build.openmpi/mpi/pt2pt/osu_bw"], "slot": "task", "count": {"per_slot": 1}}], "attributes": {"system": {"duration": 0, "cwd": "/opt/azhpc-images/ubuntu/ubuntu-22.x/ubuntu-22.04-hpc", "shell": {"options": {"rlimit": {"cpu": -1, "fsize": -1, "data": -1, "stack": 8388608, "core": -1, "nofile": 1048576, "as": -1, "rss": -1, "nproc": -1}, "cpu-affinity": "per-task"}}, "constraints": {"hostlist": ["flux-sample-0,flux-sample-29"]}}, "user": {"study_id": "osu-2-iter-1"}}, "version": 1}
+START OF EVENTLOG
+{"timestamp":1743294666.520262,"name":"init"}
+{"timestamp":1743294666.5208848,"name":"starting"}
+{"timestamp":1743294666.5504811,"name":"shell.init","context":{"service":"0-shell-fL1JH1fM","leader-rank":0,"size":2}}
+{"timestamp":1743294666.5542791,"name":"shell.start","context":{"taskmap":{"version":1,"map":[[0,2,1,1]]}}}
+{"timestamp":1743294667.665215,"name":"shell.task-exit","context":{"localid":0,"rank":0,"state":"Exited","pid":372,"wait_status":0,"signaled":0,"exitcode":0}}
+{"timestamp":1743294667.6716905,"name":"complete","context":{"status":0}}
+{"timestamp":1743294667.6717153,"name":"done"}
+

--- a/paper/osu-benchmarks/1-run-analysis.py
+++ b/paper/osu-benchmarks/1-run-analysis.py
@@ -237,6 +237,17 @@ def parse_data(indir, outdir, files):
         if exp.size == 2:
             continue
 
+        # We reran google cloud GPU size 16 with fixed results for latency and bw.
+        if (
+            exp.cloud == "google"
+            and exp.env_type == "gpu"
+            and exp.size == 16
+            and "osu-allreduce" not in filename
+            and "osu-fixed" not in filename
+        ):
+            print(f"Skipping old result {filename}")
+            continue
+
         # Cyclecloud GPU had multiple types, osu-dd and osu-hh
         # For Google Cloud GPU on GKE the point to point benchmarks
         # were run without GPU - never worked


### PR DESCRIPTION
I brought up the cluster, verified that infiniband installed successfully, and then tested osu. There were consistent segfaults across the board, and only one set of nodes that worked.

![image](https://github.com/user-attachments/assets/14a90eae-b38e-400d-817e-c493357759c3)

![image](https://github.com/user-attachments/assets/9672c291-88b4-4c5b-8fd1-28dfe17c52a9)

![image](https://github.com/user-attachments/assets/a66b2cc6-623a-46c5-bebe-c4491f65943a)


This exact setup / container / commands (switching flux submit with run) worked before, so I don't think we can debug it, especially because it's coming from our account money and not credits.
